### PR TITLE
Tracer UUIDs

### DIFF
--- a/agents.cabal
+++ b/agents.cabal
@@ -60,6 +60,7 @@ library agents-lib
     default-language: Haskell2010
     default-extensions: OverloadedStrings, OverloadedRecordDot
     exposed-modules:  System.Agents
+                    , System.Agents.Agent
                     , System.Agents.ApiKeys
                     , System.Agents.Base
                     , System.Agents.FileLoader
@@ -75,7 +76,6 @@ library agents-lib
                     , System.Agents.MCP.Base
                     , System.Agents.MCP.Server
                     , System.Agents.MCP.Server.Runtime
-                    , System.Agents.OpenAI
                     , System.Agents.Prompt
     build-depends:    base ^>=4.19.1.0,
                       aeson >=2.2.0.0,

--- a/agents.cabal
+++ b/agents.cabal
@@ -90,6 +90,7 @@ library agents-lib
                       stm,
                       text,
                       unix,
+                      uuid,
                       containers,
                       unordered-containers,
                       http-client,

--- a/src/System/Agents/Agent.hs
+++ b/src/System/Agents/Agent.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module System.Agents.OpenAI where
+module System.Agents.Agent where
 
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.STM (STM, atomically)

--- a/src/System/Agents/Agent.hs
+++ b/src/System/Agents/Agent.hs
@@ -27,12 +27,16 @@ import qualified System.Agents.Tools.IO as IOTools
 -------------------------------------------------------------------------------
 
 data Trace
+    = AgentTrace !AgentSlug !AgentId !BaseTrace
+    deriving (Show)
+
+data BaseTrace
     = OpenAITrace !OpenAI.Trace
     | StepTrace !TraceStep
     | BashToolsLoadingTrace !BashTools.LoadTrace
     | ReloadToolsTrace !(Background.Track [BashTools.ScriptDescription])
     | RunToolTrace !ToolTrace
-    | ChildrenTrace !AgentSlug Trace
+    | ChildrenTrace !Trace
     deriving (Show)
 
 data TraceStep
@@ -44,6 +48,7 @@ data TraceStep
 data Runtime
     = Runtime
     { agentSlug :: AgentSlug
+    , agentId :: AgentId
     , agentAnnounce :: AgentAnnounce
     , agentTracer :: Tracer IO Trace
     , agentAuthenticatedHttpClientRuntime :: HttpClient.Runtime
@@ -61,7 +66,7 @@ type BackgroundTools =
     )
 
 backgroundToolDir ::
-    Tracer IO Trace ->
+    Tracer IO BaseTrace ->
     FilePath ->
     IO (Either String BackgroundTools)
 backgroundToolDir tracer tooldir = do
@@ -104,10 +109,12 @@ newRuntime ::
     OpenAI.ApiKey ->
     OpenAI.Model ->
     FilePath ->
-    [Registration OpenAI.Tool OpenAI.ToolCall] ->
+    [AgentSlug -> AgentId -> Registration OpenAI.Tool OpenAI.ToolCall] ->
     IO (Either String Runtime)
-newRuntime slug announce tracer apiKey model tooldir ioTools = do
-    toolz <- backgroundToolDir tracer tooldir
+newRuntime slug announce tracer apiKey model tooldir mkIoTools = do
+    uid <- newAgentId
+    let ioTools = [mk slug uid | mk <- mkIoTools]
+    toolz <- backgroundToolDir (contramap (AgentTrace slug uid) tracer) tooldir
     case toolz of
         Left err -> pure $ Left err
         Right (bkgTools, triggerReloadTools) -> do
@@ -117,7 +124,7 @@ newRuntime slug announce tracer apiKey model tooldir ioTools = do
             let registerTools xs = fmap registerBashToolInOpenAI xs
             let bkgToolsWithIOTools = fmap (appendIOTools . registerTools) bkgTools
             let readTools = Background.readBackgroundVal bkgToolsWithIOTools
-            let rt = Runtime slug announce tracer httpRt model readTools triggerReloadTools
+            let rt = Runtime slug uid announce tracer httpRt model readTools triggerReloadTools
             pure $ Right rt
 
 data AgentFunctions r
@@ -162,15 +169,16 @@ stepWith ::
     PendingQuery ->
     IO r
 stepWith _ _ next hist Done = next $ OnDone hist
-stepWith (Runtime _ _ tracer httpRt model tools _) functions next hist pendingQuery = do
+stepWith rt@(Runtime _ _ _ tracer httpRt model tools _) functions next hist pendingQuery = do
+    let baseTracer = contramap (AgentTrace rt.agentSlug rt.agentId) tracer
     let query = getQuery pendingQuery
     registeredTools <- tools
     let openAITools = fmap declareTool registeredTools
     let payload = OpenAI.simplePayload model openAITools hist query
-    llmResponse <- OpenAI.callLLMPayload (contramap OpenAITrace tracer) httpRt model.modelBaseUrl payload
+    llmResponse <- OpenAI.callLLMPayload (contramap (AgentTrace rt.agentSlug rt.agentId . OpenAITrace) tracer) httpRt model.modelBaseUrl payload
     case Aeson.parseEither OpenAI.parseLLMResponse =<< llmResponse of
         Right rsp -> do
-            runTracer tracer (StepTrace $ GotResponse rsp)
+            runTracer baseTracer (StepTrace $ GotResponse rsp)
             case Maybe.fromMaybe [] rsp.rspToolCalls of
                 [] -> do
                     nextQuery <- functions.waitAdditionalQuery
@@ -179,7 +187,7 @@ stepWith (Runtime _ _ tracer httpRt model tools _) functions next hist pendingQu
                             (maybe Done SomeQuery nextQuery)
                             (hist <> Seq.singleton (OpenAI.PromptAnswered query rsp))
                 toolcalls -> do
-                    responses <- mapConcurrently (openAICallTool tracer registeredTools) toolcalls
+                    responses <- mapConcurrently (openAICallTool baseTracer registeredTools) toolcalls
                     let toolResults = fmap OpenAI.ToolCalled $ yankResults responses
                     next $
                         PromptMore
@@ -189,7 +197,7 @@ stepWith (Runtime _ _ tracer httpRt model tools _) functions next hist pendingQu
             next $ OnError err
 
 openAICallTool ::
-    Tracer IO Trace ->
+    Tracer IO BaseTrace ->
     [Registration OpenAI.Tool OpenAI.ToolCall] ->
     OpenAI.ToolCall ->
     IO (CallResult OpenAI.ToolCall)
@@ -283,8 +291,8 @@ instance Aeson.FromJSON PromptOtherAgent where
         PromptOtherAgent
             <$> v Aeson..: "what"
 
-turnAgentRuntimeIntoIOTool :: AgentSlug -> Runtime -> Registration OpenAI.Tool OpenAI.ToolCall
-turnAgentRuntimeIntoIOTool callerSlug rt =
+turnAgentRuntimeIntoIOTool :: Runtime -> AgentSlug -> AgentId -> Registration OpenAI.Tool OpenAI.ToolCall
+turnAgentRuntimeIntoIOTool rt callerSlug callerId =
     registerIOScriptInOpenAI io props
   where
     props =
@@ -305,8 +313,8 @@ turnAgentRuntimeIntoIOTool callerSlug rt =
     runSubAgent txt =
         openAIAgent (nestTracer rt) agentFunctions txt
 
-    nestTracer baseRuntime =
-        baseRuntime{agentTracer = contramap (ChildrenTrace callerSlug) baseRuntime.agentTracer}
+    nestTracer childRuntime =
+        childRuntime{agentTracer = contramap (AgentTrace callerSlug callerId . ChildrenTrace) childRuntime.agentTracer}
 
     agentFunctions =
         AgentFunctions

--- a/src/System/Agents/Base.hs
+++ b/src/System/Agents/Base.hs
@@ -1,8 +1,19 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 
 module System.Agents.Base where
 
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
+import Data.UUID (UUID)
+import qualified Data.UUID.V4 as UUID
 
 type AgentSlug = Text
 type AgentAnnounce = Text
+
+newtype AgentId = AgentId UUID
+    deriving (Show, Ord, Eq, FromJSON, ToJSON)
+
+newAgentId :: IO AgentId
+newAgentId =
+    AgentId <$> UUID.nextRandom

--- a/src/System/Agents/MCP/Server.hs
+++ b/src/System/Agents/MCP/Server.hs
@@ -16,10 +16,10 @@ import qualified Data.Text as Text
 import qualified Network.JSONRPC as Rpc
 import UnliftIO (async, liftIO, stderr, stdout)
 
+import qualified System.Agents.Agent as Agent
 import qualified System.Agents.FileLoader as FileLoader
 import qualified System.Agents.LLMs.OpenAI as OpenAI
 import System.Agents.MCP.Base as Mcp
-import qualified System.Agents.OpenAI as Agent
 import qualified System.Agents.Prompt as Prompt
 
 import System.Agents.MCP.Server.Runtime

--- a/src/System/Agents/Prompt.hs
+++ b/src/System/Agents/Prompt.hs
@@ -18,10 +18,10 @@ import GHC.IO.Handle (Handle)
 import Prod.Tracer (Tracer (..), contramap, silent)
 import System.IO (stderr, stdout)
 
+import qualified System.Agents.Agent as Agent
 import System.Agents.Base (AgentSlug)
 import qualified System.Agents.FileLoader as FileLoader
 import qualified System.Agents.LLMs.OpenAI as OpenAI
-import qualified System.Agents.OpenAI as Agent
 import qualified System.Agents.Tools as Tools
 import qualified System.Agents.Tools.Bash as Tools
 import qualified System.Agents.Tools.IO as Tools


### PR DESCRIPTION
Enables to get UUIDs per agent, which will improve traceability of conversations, and a better nesting (albeit a tad redundant given the constructor names).

```console
AgentTrace (AgentTrace "boss" (AgentId a52d29a1-d8b2-4ef3-ae14-52ce88bcb3f5) (ChildrenTrace (AgentTrace "net_expert" (AgentId e8d64322-f6b6-4cf1-98f7-a9e7c5463102) (OpenAITrace (GotChatCompletion (Object (fromList [("choices",Array [Object (fromList [("finish_reason",String "stop"),("index",Number 0.0),("logprobs",Null),("message",Object (fromList [("annotations",Array []),("content",String "The ping results for `dicioccio.fr` are as follows:\n\n- IP Address: **163.172.53.34**\n- Response times:\n  - Reply 1: 5.19 ms\n  - Reply 2: 5.53 ms\n  - Reply 3: 7.41 ms\n\n### Summary:\n- **Packets Transmitted**: 3\n- **Packets Received**: 3\n- **Packet Loss**: 0%\n- ** [snip]
```