### PR TITLE
Tracer/http sink

### DIFF
--- a/agents.cabal
+++ b/agents.cabal
@@ -71,6 +71,7 @@ library agents-lib
                     , System.Agents.Tools.IO
                     , System.Agents.LLMs.OpenAI
                     , System.Agents.HttpClient
+                    , System.Agents.HttpLogger
                     , System.Agents.CLI.Base
                     , System.Agents.CLI.InitProject
                     , System.Agents.MCP.Base
@@ -82,6 +83,7 @@ library agents-lib
                       aeson-pretty,
                       async,
                       bytestring,
+                      contravariant,
                       directory,
                       filepath,
                       process,
@@ -122,6 +124,7 @@ executable agents-exe
     build-depends:    base ^>=4.19.1.0,
                       agents-lib,
                       aeson,
+                      contravariant,
                       text,
                       prodapi,
                       optparse-applicative

--- a/dbs/README.md
+++ b/dbs/README.md
@@ -1,0 +1,1 @@
+migration files for http-log over postgrest

--- a/dbs/agents_logs/migrations/owner/0001-init.sql
+++ b/dbs/agents_logs/migrations/owner/0001-init.sql
@@ -1,0 +1,14 @@
+create table if not exists agent_logs_reports (
+  id serial primary key,
+  created_at timestamp default current_timestamp,
+  e jsonb
+);
+
+grant usage on schema public to agents_log_inserter;
+grant insert (e) on agent_logs_reports to agents_log_inserter;
+grant usage, select on agent_logs_reports_id_seq to agents_log_inserter;
+
+grant insert (e) on agent_logs_reports to agents_log_anon;
+grant usage, select on agent_logs_reports_id_seq to agents_log_anon;
+grant usage on schema public to agents_log_anon;
+grant select on agent_logs_reports to agents_log_anon;

--- a/dbs/agents_logs/migrations/owner/tip.sql
+++ b/dbs/agents_logs/migrations/owner/tip.sql
@@ -1,0 +1,4 @@
+-- migrate.after: 0001-init.sql
+
+notify pgrst;
+

--- a/dbs/agents_logs/migrations/superuser/tip.sql
+++ b/dbs/agents_logs/migrations/superuser/tip.sql
@@ -1,0 +1,3 @@
+-- nothing so far
+
+grant agents_log_anon to agents_log_inserter;

--- a/dbs/agents_logs/run-migrations-locally.sh
+++ b/dbs/agents_logs/run-migrations-locally.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+function config () {
+        salmon-migrator config migrate \
+                --db agents_log \
+                --db-owner agents_log_owner \
+                --db-passfile ./passes/db.passfile \
+                --db-extra-user agents_log_inserter \
+                --db-extra-user agents_log_anon
+}
+
+cfg=$(config)
+
+case $1 in
+config) echo "${cfg}" ;;
+pretty) echo "${cfg}" | jq . ;;
+dot) echo "${cfg}" | salmon-migrator run dag ;;
+run) echo "${cfg}" | sudo "$(which salmon-migrator)" run up;;
+*) echo "config|pretty|dot|run"
+esac
+

--- a/src/System/Agents/HttpLogger.hs
+++ b/src/System/Agents/HttpLogger.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+
+module System.Agents.HttpLogger where
+
+import Data.Aeson (ToJSON (..))
+import qualified Data.ByteString.Lazy as LByteString
+import qualified Network.HTTP.Client as HttpClient
+import Prod.Tracer (Tracer (..))
+
+import qualified System.Agents.HttpClient as AgentsHttpClient
+
+data Runtime
+    = Runtime
+    { clientRuntime :: AgentsHttpClient.Runtime
+    , endpoint :: AgentsHttpClient.Url "log-sink"
+    }
+
+-------------------------------------------------------------------------------
+httpLog :: (ToJSON val) => Runtime -> Tracer IO AgentsHttpClient.Trace -> val -> IO (Either AgentsHttpClient.ScoopError (HttpClient.Response LByteString.ByteString))
+httpLog rt clientTracer obj =
+    rt.clientRuntime.post clientTracer rt.endpoint (Just $ toJSON obj)
+
+httpTracer :: (ToJSON val) => Runtime -> Tracer IO AgentsHttpClient.Trace -> Tracer IO val
+httpTracer rt clientTracer =
+    Tracer $ \x -> httpLog rt clientTracer x >> pure ()


### PR DESCRIPTION
Introduce a (naive for now) optional HTTP sink logger, as well as some migration file for a PostgREST-enablable compatible sink, and a JSON serialization for key events (subject to changes).


Type of log we get show the nesting of calls, from `boss` agent to `web-news` agent, each having their instantiation ID.

```json
{
  "s": "boss",
  "x": {
    "x": "child",
    "sub": {
      "e": {
        "s": "web-news",
        "x": {
          "a": "result",
          "v": {
            "error": {
              "code": "insufficient_quota",
              "type": "insufficient_quota",
              "param": null,
              "message": "You exceeded your current quota, please check your plan and billing details. For more information on this error, read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors."
            }
          },
          "x": "llm"
        },
        "id": "b0633c57-bbbe-44d4-8082-c8b2d07734c7"
      }
    }
  },
  "id": "5a998f5c-e62b-49f1-91ad-e6def35662ec"
}
```