### PR TITLE
Mcp/multi agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,15 @@ A few environment variables may affect somme commands.
 ## Using as an MCP server
 
 The command `agents-exe mcp-server` runs a (stdin/stdout) MCP server exposing
-the agent as a single tool.  It has been shown to work with Claude-desktop.  I
+agents as individual tools.  It has been shown to work with Claude-desktop.  I
 would call the support as still experimental at this point, expect some changes
 and extra features (e.g., exposing just bash-tools without agent files so that
 the MCP-client becomes the agent).
+
+The name of tools exposed over MCP is deterministic across runs provided you
+run the `mcp-server` command with the same `--agent-file` in the same order.
+This can be annoying when reading logs. I suspect I'll eventually make them
+more deterministic.
 
 ## Using as a library
 

--- a/agents.cabal
+++ b/agents.cabal
@@ -86,6 +86,7 @@ library agents-lib
                       contravariant,
                       directory,
                       filepath,
+                      formatting,
                       process,
                       process-extras,
                       prodapi,

--- a/src/System/Agents/MCP/Server/Runtime.hs
+++ b/src/System/Agents/MCP/Server/Runtime.hs
@@ -21,12 +21,17 @@ import UnliftIO (Async, IORef, MonadIO, MonadUnliftIO, async, atomicModifyIORef,
 import System.Agents.MCP.Base as Mcp
 import qualified System.Agents.Prompt as Prompt
 
+data MappedTool
+    = ExpertAgentAsPrompt Mcp.Name Prompt.AgentInfo
+
+type MappedTools = [MappedTool]
+
 data Runtime = Runtime
-    { agentInfo :: Prompt.AgentInfo -- todo: replace into mapped tools
+    { mappedTools :: MappedTools
     , actions :: IORef [(Rpc.Request, Async ())]
     }
 
-initRuntime :: Prompt.AgentInfo -> IO Runtime
+initRuntime :: MappedTools -> IO Runtime
 initRuntime ai =
     Runtime ai <$> newIORef []
 
@@ -75,8 +80,8 @@ instance MonadReader Runtime McpStack where
 askRuntime :: Rpc.JSONRPCT McpStack Runtime
 askRuntime = lift ask
 
-askAgentInfo :: Rpc.JSONRPCT McpStack Prompt.AgentInfo
-askAgentInfo = agentInfo <$> lift ask
+askMappedTools :: Rpc.JSONRPCT McpStack MappedTools
+askMappedTools = mappedTools <$> lift ask
 
 -- A modified runJSONRPCT that allows to flush and add a carriage return after
 -- every full json payload (the original code only allows bytestrings).

--- a/src/System/Agents/Prompt.hs
+++ b/src/System/Agents/Prompt.hs
@@ -221,6 +221,7 @@ mainInteractiveAgent props = do
     queryOrNothing t = Just t
 
 augmentMainAgentPromptWithSubAgents :: [Agent.Runtime] -> Text -> Text
+augmentMainAgentPromptWithSubAgents [] base = base
 augmentMainAgentPromptWithSubAgents agents base =
     Text.unlines
         [ base


### PR DESCRIPTION
Supports passing multiple agents file over MCP.

Makes --agent-file a repeated-yet-optional argument.

In the `mcp-server` command:

Each agent then get exposed as `ask_<slug>_<idx>`, the `idx` depends on the location on the command-line argument.

In other commands:

only the first argument is used (for now)