### PR TITLE
Tracing/more uuids

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -311,8 +311,13 @@ toJsonTrace x = case x of
         encodeBaseTrace_Loading tr
     encodeBaseTrace (BaseAgent.AgentTrace_Info _ _ tr) =
         encodeBaseTrace_Info tr
-    encodeBaseTrace (BaseAgent.AgentTrace_Conversation _ _ tr) =
-        encodeBaseTrace_Conversation tr
+    encodeBaseTrace (BaseAgent.AgentTrace_Conversation _ _ convId tr) = do
+        baseVal <- encodeBaseTrace_Conversation tr
+        Just $
+            Aeson.object
+                [ "c" .= convId
+                , "v" .= baseVal
+                ]
 
     encodeBaseTrace_Loading :: BaseAgent.LoadingTrace -> Maybe Aeson.Value
     encodeBaseTrace_Loading bt =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -331,38 +331,42 @@ toJsonTrace x = case x of
                         , "v" .= val
                         , "u" .= uuid
                         ]
-            (BaseAgent.RunToolTrace (ToolsTrace.BashToolsTrace (ToolsTrace.RunCommandStart cmd args))) ->
+            (BaseAgent.RunToolTrace uuid (ToolsTrace.BashToolsTrace (ToolsTrace.RunCommandStart cmd args))) ->
                 Just $
                     Aeson.object
                         [ "x" .= ("run-tool" :: Text.Text)
+                        , "u" .= uuid
                         , "flavor" .= ("bash" :: Text.Text)
                         , "action" .= ("start" :: Text.Text)
                         , "cmd" .= cmd
                         , "args" .= args
                         ]
-            (BaseAgent.RunToolTrace (ToolsTrace.BashToolsTrace (ToolsTrace.RunCommandStopped cmd args code _ _))) ->
+            (BaseAgent.RunToolTrace uuid (ToolsTrace.BashToolsTrace (ToolsTrace.RunCommandStopped cmd args code _ _))) ->
                 Just $
                     Aeson.object
                         [ "x" .= ("run-tool" :: Text.Text)
+                        , "u" .= uuid
                         , "flavor" .= ("bash" :: Text.Text)
                         , "action" .= ("stop" :: Text.Text)
                         , "code-str" .= show code -- todo: code
                         , "cmd" .= cmd
                         , "args" .= args
                         ]
-            (BaseAgent.RunToolTrace (ToolsTrace.IOToolsTrace (ToolsTrace.IOScriptStarted desc input))) ->
+            (BaseAgent.RunToolTrace uuid (ToolsTrace.IOToolsTrace (ToolsTrace.IOScriptStarted desc input))) ->
                 Just $
                     Aeson.object
                         [ "x" .= ("run-tool" :: Text.Text)
+                        , "u" .= uuid
                         , "flavor" .= ("io" :: Text.Text)
                         , "action" .= ("start" :: Text.Text)
                         , "tool" .= desc.ioSlug
                         , "input" .= input
                         ]
-            (BaseAgent.RunToolTrace (ToolsTrace.IOToolsTrace (ToolsTrace.IOScriptStopped desc input output))) ->
+            (BaseAgent.RunToolTrace uuid (ToolsTrace.IOToolsTrace (ToolsTrace.IOScriptStopped desc input output))) ->
                 Just $
                     Aeson.object
                         [ "x" .= ("run-tool" :: Text.Text)
+                        , "u" .= uuid
                         , "flavor" .= ("io" :: Text.Text)
                         , "action" .= ("stop" :: Text.Text)
                         , "tool" .= desc.ioSlug

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -313,21 +313,23 @@ toJsonTrace x = case x of
             (BaseAgent.ReloadToolsTrace _) -> Nothing
             (BaseAgent.StepTrace _) ->
                 Nothing
-            (BaseAgent.LLMTrace (LLMTrace.HttpClientTrace _)) ->
+            (BaseAgent.LLMTrace _ (LLMTrace.HttpClientTrace _)) ->
                 Nothing
-            (BaseAgent.LLMTrace (LLMTrace.CallChatCompletion val)) ->
+            (BaseAgent.LLMTrace uuid (LLMTrace.CallChatCompletion val)) ->
                 Just $
                     Aeson.object
                         [ "x" .= ("llm" :: Text.Text)
                         , "a" .= ("call" :: Text.Text)
                         , "v" .= val
+                        , "u" .= uuid
                         ]
-            (BaseAgent.LLMTrace (LLMTrace.GotChatCompletion val)) ->
+            (BaseAgent.LLMTrace uuid (LLMTrace.GotChatCompletion val)) ->
                 Just $
                     Aeson.object
                         [ "x" .= ("llm" :: Text.Text)
                         , "a" .= ("result" :: Text.Text)
                         , "v" .= val
+                        , "u" .= uuid
                         ]
             (BaseAgent.RunToolTrace (ToolsTrace.BashToolsTrace (ToolsTrace.RunCommandStart cmd args))) ->
                 Just $

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -311,7 +311,7 @@ toJsonTrace x = case x of
         case bt of
             (BaseAgent.BashToolsLoadingTrace _) -> Nothing
             (BaseAgent.ReloadToolsTrace _) -> Nothing
-            (BaseAgent.StepTrace _) ->
+            (BaseAgent.InfoTrace _) ->
                 Nothing
             (BaseAgent.LLMTrace _ (LLMTrace.HttpClientTrace _)) ->
                 Nothing

--- a/src/System/Agents/Agent.hs
+++ b/src/System/Agents/Agent.hs
@@ -28,15 +28,6 @@ import qualified System.Agents.Tools.IO as IOTools
 
 -------------------------------------------------------------------------------
 
--- problem here: AgentTrace generally is selected at runtime initialization
--- meanwhile a conversation can occur multiple time for a same initialization
--- so we need have a separation in trace between:
--- per-initialized agent
--- per-conversation
--- this will help case like
---  boss > expert1 (prompt-abc)
---  boss > expert1 (prompt-def)
--- todo: add conversationId to AgentTrace_Conversation
 type ConversationId = UUID
 
 data Trace
@@ -200,7 +191,7 @@ stepWith ::
     LLM.History ->
     PendingQuery ->
     IO r
-stepWith conversationId _ _ next hist Done = next $ OnDone hist
+stepWith _ _ _ next hist Done = next $ OnDone hist
 stepWith conversationId rt@(Runtime _ _ _ tracer httpRt model tools _) functions next hist pendingQuery = do
     let convTracer = contramap (AgentTrace_Conversation rt.agentSlug rt.agentId conversationId) tracer
     let infoTracer = contramap (AgentTrace_Info rt.agentSlug rt.agentId) tracer

--- a/src/System/Agents/Agent.hs
+++ b/src/System/Agents/Agent.hs
@@ -37,7 +37,7 @@ data BaseTrace
     | StepTrace !TraceStep
     | BashToolsLoadingTrace !BashTools.LoadTrace
     | ReloadToolsTrace !(Background.Track [BashTools.ScriptDescription])
-    | RunToolTrace !ToolTrace
+    | RunToolTrace !UUID !ToolTrace
     | ChildrenTrace !Trace
     deriving (Show)
 
@@ -215,7 +215,8 @@ llmCallTool tracer registrations call =
         case spec of
             Nothing -> pure $ ToolNotFound call
             Just (t, v) -> do
-                ret <- t.toolRun (contramap RunToolTrace tracer) v
+                toolcallUUID <- UUID.nextRandom
+                ret <- t.toolRun (contramap (RunToolTrace toolcallUUID) tracer) v
                 pure $ mapCallResult (const call) ret
 
 registerBashToolInLLM ::

--- a/src/System/Agents/MCP/Server.hs
+++ b/src/System/Agents/MCP/Server.hs
@@ -182,7 +182,7 @@ handleMsg req (CallToolRequestMsg callTool) = do
             case extractPrompt callTool of
                 Nothing -> pure $ Left "no prompt given"
                 (Just query) -> do
-                    liftIO $ Agent.llmAgent ai.agentRuntime agentFunctions query
+                    liftIO $ Agent.handleConversation ai.agentRuntime agentFunctions query
         Nothing -> do
             pure $ Left $ Text.unpack $ "no matching tool for " <> callTool.name
     let rsp =

--- a/src/System/Agents/Prompt.hs
+++ b/src/System/Agents/Prompt.hs
@@ -138,7 +138,7 @@ mainOneShotText props query = do
             (\err -> putStrLn $ unlines ["execution error", err])
             (\hist -> OpenAI.printLastAnswer hist)
     runMainAgent rt = do
-        Agent.llmAgent rt agentFunctions query
+        Agent.handleConversation rt agentFunctions query
 
 mainInteractiveAgent :: Props -> IO ()
 mainInteractiveAgent props = do
@@ -159,7 +159,7 @@ mainInteractiveAgent props = do
     runMainAgent ai = do
         let nextQuery = askQuery ai
         query <- nextQuery
-        Agent.llmAgent ai.agentRuntime (agentFunctions nextQuery) query
+        Agent.handleConversation ai.agentRuntime (agentFunctions nextQuery) query
 
     askQuery :: AgentInfo -> IO Text
     askQuery ai = do
@@ -301,7 +301,7 @@ renderBaseAgentTrace tr = case tr of
         Text.unwords ["to: llm"]
     Agent.LLMTrace _ (OpenAI.GotChatCompletion x) ->
         Text.unwords ["from: llm", jsonTxt x]
-    Agent.StepTrace (Agent.GotResponse rsp) ->
+    Agent.InfoTrace (Agent.GotResponse rsp) ->
         Text.unwords [Text.decodeUtf8 $ LByteString.toStrict $ Aeson.encode rsp.chosenMessage]
     Agent.ChildrenTrace (Agent.AgentTrace slug _ sub) ->
         Text.unwords ["(", slug, ")", renderBaseAgentTrace sub]

--- a/src/System/Agents/Prompt.hs
+++ b/src/System/Agents/Prompt.hs
@@ -285,16 +285,16 @@ renderBaseAgentTrace :: Agent.BaseTrace -> Text
 renderBaseAgentTrace tr = case tr of
     Agent.ReloadToolsTrace _ -> "(reload-tools...)"
     Agent.BashToolsLoadingTrace _ -> "(reload-tools...)"
-    Agent.RunToolTrace (Tools.BashToolsTrace (Tools.RunCommandStart p args)) ->
+    Agent.RunToolTrace _ (Tools.BashToolsTrace (Tools.RunCommandStart p args)) ->
         Text.unwords ["bash-tool", "start", Text.pack p, Text.unwords $ map Text.pack args]
-    Agent.RunToolTrace (Tools.BashToolsTrace (Tools.RunCommandStopped p args code _ _)) ->
+    Agent.RunToolTrace _ (Tools.BashToolsTrace (Tools.RunCommandStopped p args code _ _)) ->
         Text.unlines
             [ Text.unwords ["bash-tool", "stopped", Text.pack p, Text.unwords $ map Text.pack args]
             , Text.pack $ show code
             ]
-    Agent.RunToolTrace (Tools.IOToolsTrace (Tools.IOScriptStarted desc _)) ->
+    Agent.RunToolTrace _ (Tools.IOToolsTrace (Tools.IOScriptStarted desc _)) ->
         Text.unwords ["io-tool", desc.ioSlug, "start"]
-    Agent.RunToolTrace (Tools.IOToolsTrace (Tools.IOScriptStopped desc _ _)) ->
+    Agent.RunToolTrace _ (Tools.IOToolsTrace (Tools.IOScriptStopped desc _ _)) ->
         Text.unwords ["io-tool", desc.ioSlug, "stop"]
     Agent.LLMTrace _ (OpenAI.HttpClientTrace _) -> "(http)"
     Agent.LLMTrace _ (OpenAI.CallChatCompletion _) ->

--- a/src/System/Agents/Prompt.hs
+++ b/src/System/Agents/Prompt.hs
@@ -244,7 +244,7 @@ traceSilent = silent
 traceWaitingOpenAIRateLimits :: OpenAI.ApiLimits -> (OpenAI.WaitAction -> IO ()) -> Tracer IO Trace
 traceWaitingOpenAIRateLimits lims onWait = Tracer f
   where
-    f (AgentTrace (Agent.AgentTrace _ _ (Agent.LLMTrace tr))) =
+    f (AgentTrace (Agent.AgentTrace _ _ (Agent.LLMTrace _ tr))) =
         runTracer (OpenAI.waitRateLimit lims onWait) tr
     f _ = pure ()
 
@@ -255,7 +255,7 @@ tracePrintingTextResponses = Tracer f
         g [slug] trace
     f _ = pure ()
 
-    g pfx (Agent.LLMTrace (OpenAI.GotChatCompletion x)) =
+    g pfx (Agent.LLMTrace _ (OpenAI.GotChatCompletion x)) =
         case Aeson.parseEither OpenAI.parseLLMResponse x of
             Left _ -> pure ()
             Right rsp ->
@@ -296,10 +296,10 @@ renderBaseAgentTrace tr = case tr of
         Text.unwords ["io-tool", desc.ioSlug, "start"]
     Agent.RunToolTrace (Tools.IOToolsTrace (Tools.IOScriptStopped desc _ _)) ->
         Text.unwords ["io-tool", desc.ioSlug, "stop"]
-    Agent.LLMTrace (OpenAI.HttpClientTrace _) -> "(http)"
-    Agent.LLMTrace (OpenAI.CallChatCompletion _) ->
+    Agent.LLMTrace _ (OpenAI.HttpClientTrace _) -> "(http)"
+    Agent.LLMTrace _ (OpenAI.CallChatCompletion _) ->
         Text.unwords ["to: llm"]
-    Agent.LLMTrace (OpenAI.GotChatCompletion x) ->
+    Agent.LLMTrace _ (OpenAI.GotChatCompletion x) ->
         Text.unwords ["from: llm", jsonTxt x]
     Agent.StepTrace (Agent.GotResponse rsp) ->
         Text.unwords [Text.decodeUtf8 $ LByteString.toStrict $ Aeson.encode rsp.chosenMessage]


### PR DESCRIPTION
Reworks the Trace structure to introduce the notion of conversation in the payload.
Also weaves through the conversation-id through IO-defined tools.

This way we can get the contextualized call-trace across tool and cross-agent calls.


```json
{
  "val": {
    "val": {
      "x": "child",
      "sub": {
        "e": {
          "val": {
            "val": {
              "x": "llm",
              "val": {
                "model": "gpt-4o-mini",
                "tools": [
                  {
                    "type": "function",
                    "function": {
                      "name": "bash_fetch-news",
                      "parameters": {
                        "type": "object",
                        "required": [
                          "urls"
                        ],
                        "properties": {
                          "urls": {
                            "type": "string",
                            "description": "A comma-separated list of URLs to fetch news from"
                          }
                        },
                        "additionalProperties": false
                      },
                      "description": "fetches news articles from specified websites"
                    }
                  },
                ],
              , "SNIPPED": "extra payload removed for brevity"
              },
              "action": "call",
              "call-id": "0503d347-7dc0-48c2-810c-d1f474b76283"
            },
            "conv-id": "daa81867-41e7-4aa0-a5de-68c6d0f97b2b"
          },
          "slug": "web-news",
          "agent-id": "1b692ad3-7f3d-49c5-ab0d-d3d994122d39"
        }
      }
    },
    "conv-id": "3c7124af-081e-4101-a455-8644d5ae7003"
  },
  "slug": "boss",
  "agent-id": "3a3d83b0-b28e-437f-a72a-32cde5000278"
}
```