### PR TITLE
Memory add some History-specific logs

### DIFF
--- a/agents.cabal
+++ b/agents.cabal
@@ -70,6 +70,7 @@ library agents-lib
                     , System.Agents.Tools.Bash
                     , System.Agents.Tools.IO
                     , System.Agents.LLMs.OpenAI
+                    , System.Agents.Memory
                     , System.Agents.HttpClient
                     , System.Agents.HttpLogger
                     , System.Agents.CLI

--- a/agents/toolsmith.json
+++ b/agents/toolsmith.json
@@ -31,7 +31,8 @@
       "example3:",
       "{ \"slug\": \"get-date\"\n, \"description\": \"get current date\"\n, \"args\":\n  [ ]\n}",
       "",
-      "on 'run' he bash scripts actually executes the command"
+      "on 'run' bash scripts actually execute the command",
+      "on 'run' bash scripts optionally return an extra output line \"operation successful\" if we would expect the command to return no result"
     ]
   }
 }

--- a/dbs/agents_logs/migrations/owner/0001-init.sql
+++ b/dbs/agents_logs/migrations/owner/0001-init.sql
@@ -1,14 +1,7 @@
+
 create table if not exists agent_logs_reports (
   id serial primary key,
   created_at timestamp default current_timestamp,
   e jsonb
 );
 
-grant usage on schema public to agents_log_inserter;
-grant insert (e) on agent_logs_reports to agents_log_inserter;
-grant usage, select on agent_logs_reports_id_seq to agents_log_inserter;
-
-grant insert (e) on agent_logs_reports to agents_log_anon;
-grant usage, select on agent_logs_reports_id_seq to agents_log_anon;
-grant usage on schema public to agents_log_anon;
-grant select on agent_logs_reports to agents_log_anon;

--- a/dbs/agents_logs/migrations/owner/0002-add-memory.sql
+++ b/dbs/agents_logs/migrations/owner/0002-add-memory.sql
@@ -1,0 +1,18 @@
+
+create table if not exists agent_conversations (
+  id serial primary key,
+  created_at timestamp default current_timestamp,
+  
+  root_conversation_id uuid not null,
+
+  conversation_id uuid not null,
+  agent_slug text not null,
+  agent_execution_id uuid not null,
+
+  parent_conversation_id uuid,
+  parent_agent_slug text,
+  parent_agent_execution_id uuid,
+
+  pending_query jsonb not null,
+  llm_history jsonb not null
+);

--- a/dbs/agents_logs/migrations/owner/patch-local-acl.sql
+++ b/dbs/agents_logs/migrations/owner/patch-local-acl.sql
@@ -1,0 +1,18 @@
+grant usage on schema public to agents_log_inserter;
+
+-- migrate.after: 0001-init.sql
+grant insert (e) on agent_logs_reports to agents_log_inserter;
+grant usage, select on agent_logs_reports_id_seq to agents_log_inserter;
+grant insert (e) on agent_logs_reports to agents_log_anon;
+grant usage, select on agent_logs_reports_id_seq to agents_log_anon;
+grant usage on schema public to agents_log_anon;
+grant select on agent_logs_reports to agents_log_anon;
+
+-- migrate.after: 0002-add-memory.sql
+
+grant insert (root_conversation_id,conversation_id,agent_slug,agent_execution_id,parent_conversation_id, parent_agent_slug, parent_agent_execution_id, pending_query, llm_history) on agent_conversations to agents_log_inserter;
+grant usage, select on agent_conversations_id_seq to agents_log_inserter;
+grant insert (root_conversation_id,conversation_id,agent_slug,agent_execution_id,parent_conversation_id, parent_agent_slug, parent_agent_execution_id, pending_query, llm_history) on agent_conversations to agents_log_anon;
+grant usage, select on agent_conversations_id_seq to agents_log_anon;
+grant usage on schema public to agents_log_anon;
+grant select on agent_conversations to agents_log_anon;

--- a/dbs/agents_logs/migrations/owner/tip.sql
+++ b/dbs/agents_logs/migrations/owner/tip.sql
@@ -1,4 +1,6 @@
 -- migrate.after: 0001-init.sql
+-- migrate.after: 0002-add-memory.sql
+-- migrate.after: patch-local-acl.sql
 
 notify pgrst;
 

--- a/dbs/agents_logs/migrations/superuser/tip.sql
+++ b/dbs/agents_logs/migrations/superuser/tip.sql
@@ -1,3 +1,4 @@
 -- nothing so far
 
+create extension if not exists "uuid-ossp";
 grant agents_log_anon to agents_log_inserter;

--- a/src/System/Agents/Base.hs
+++ b/src/System/Agents/Base.hs
@@ -17,3 +17,10 @@ newtype AgentId = AgentId UUID
 newAgentId :: IO AgentId
 newAgentId =
     AgentId <$> UUID.nextRandom
+
+newtype ConversationId = ConversationId UUID
+    deriving (Show, Ord, Eq, FromJSON, ToJSON)
+
+newConversationId :: IO ConversationId
+newConversationId =
+    ConversationId <$> UUID.nextRandom

--- a/src/System/Agents/CLI.hs
+++ b/src/System/Agents/CLI.hs
@@ -172,10 +172,10 @@ renderAgentTrace (Agent.AgentTrace_Conversation slug _ _ tr) =
         [ mconcat ["@", slug, ":"]
         , renderConversationAgentTrace tr
         ]
-renderAgentTrace (Agent.AgentTrace_Info slug _ tr) =
+renderAgentTrace (Agent.AgentTrace_Memorize slug _ _ tr) =
     Text.unlines
         [ mconcat ["@", slug, ":"]
-        , renderInfoAgentTrace tr
+        , renderMemorizeAgentTrace tr
         ]
 
 renderLoadingAgentTrace :: Agent.LoadingTrace -> Text
@@ -183,13 +183,18 @@ renderLoadingAgentTrace tr = case tr of
     Agent.ReloadToolsTrace _ -> "(reload-tools...)"
     Agent.BashToolsLoadingTrace _ -> "(reload-tools...)"
 
-renderInfoAgentTrace :: Agent.InfoTrace -> Text
-renderInfoAgentTrace tr = case tr of
-    Agent.GotResponse rsp ->
-        Text.unwords [Text.decodeUtf8 $ LByteString.toStrict $ Aeson.encode rsp.chosenMessage]
+renderMemorizeAgentTrace :: Agent.MemorizeTrace -> Text
+renderMemorizeAgentTrace tr = case tr of
+    Agent.Calling _ hist _ ->
+        Text.unwords [Text.pack . show $ length hist, ">>>"]
+    Agent.GotResponse _ hist _ rsp ->
+        Text.unwords [Text.pack . show $ length hist, Text.decodeUtf8 $ LByteString.toStrict $ Aeson.encode rsp.chosenMessage]
+    Agent.InteractionDone hist _ ->
+        Text.unwords [Text.pack . show $ length hist, "<<<"]
 
 renderConversationAgentTrace :: Agent.ConversationTrace -> Text
 renderConversationAgentTrace tr = case tr of
+    Agent.NewConversation -> ""
     Agent.RunToolTrace _ (Tools.BashToolsTrace (Tools.RunCommandStart p args)) ->
         Text.unwords ["bash-tool", "start", Text.pack p, Text.unwords $ map Text.pack args]
     Agent.RunToolTrace _ (Tools.BashToolsTrace (Tools.RunCommandStopped p args code _ _)) ->

--- a/src/System/Agents/LLMs/OpenAI.hs
+++ b/src/System/Agents/LLMs/OpenAI.hs
@@ -230,6 +230,7 @@ toolResponseMessages tc txt =
 data HistoryItem
     = PromptAnswered (Maybe Text) Response
     | ToolCalled (ToolCall, ByteString)
+    deriving (Show)
 
 type History = Seq HistoryItem
 

--- a/src/System/Agents/Memory.hs
+++ b/src/System/Agents/Memory.hs
@@ -1,0 +1,69 @@
+module System.Agents.Memory where
+
+import Data.Aeson (ToJSON (..), (.=))
+import qualified Data.Aeson as Aeson
+import Data.Text (Text)
+import qualified Data.Text.Encoding as Text
+import qualified System.Agents.Agent as Agent
+import System.Agents.Base
+import qualified System.Agents.LLMs.OpenAI as LLM
+
+data MemoryItem
+    = MemoryItem
+    { rootConversationId :: ConversationId
+    , conversationId :: ConversationId
+    , stepId :: Agent.StepId
+    , agentSlug :: AgentSlug
+    , agentId :: AgentId
+    , parentConversationId :: Maybe ConversationId
+    , parentAgentSlug :: Maybe AgentSlug
+    , parentAgentId :: Maybe AgentId
+    , pendingQuery :: Agent.PendingQuery
+    , llmHistory :: LLM.History
+    }
+    deriving (Show)
+
+instance ToJSON MemoryItem where
+    toJSON m =
+        Aeson.object
+            [ "root_conversation_id" .= m.rootConversationId
+            , "conversation_id" .= m.conversationId
+            , "agent_slug" .= m.agentSlug
+            , "agent_execution_id" .= m.agentId
+            , "parent_conversation_id" .= m.parentConversationId
+            , "parent_agent_slug" .= m.parentAgentSlug
+            , "parent_agent_execution_id" .= m.parentAgentId
+            , "pending_query" .= encodeQuery m.pendingQuery
+            , "llm_history" .= fmap encodeHistoryItem m.llmHistory
+            ]
+      where
+        encodeQuery :: Agent.PendingQuery -> Aeson.Value
+        encodeQuery (Agent.SomeQuery txt) =
+            Aeson.object
+                [ "type" .= ("query" :: Text)
+                , "q" .= txt
+                ]
+        encodeQuery (Agent.GaveToolAnswers) =
+            Aeson.object
+                [ "type" .= ("gave-tool-answers" :: Text)
+                ]
+        encodeQuery (Agent.Done) =
+            Aeson.object
+                [ "type" .= ("done" :: Text)
+                ]
+        encodeHistoryItem :: LLM.HistoryItem -> Aeson.Value
+        encodeHistoryItem (LLM.PromptAnswered prompt rsp) =
+            Aeson.object
+                [ "type" .= ("prompt-answered" :: Text)
+                , "prompt" .= prompt
+                , "raw" .= rsp.rawResponse
+                , "msg" .= rsp.chosenMessage
+                ]
+        encodeHistoryItem (LLM.ToolCalled (tool, res)) =
+            Aeson.object
+                [ "type" .= ("tool-called" :: Text)
+                , "raw" .= tool.rawToolCall
+                , "tool" .= tool.toolCallFunction.toolCallFunctionName.getToolName
+                , "args" .= tool.toolCallFunction.toolCallFunctionArgs
+                , "result" .= Text.decodeUtf8 res
+                ]

--- a/src/System/Agents/Tools/Bash.hs
+++ b/src/System/Agents/Tools/Bash.hs
@@ -32,15 +32,18 @@ data RunTrace
 -------------------------------------------------------------------------------
 data ScriptArgArity
     = Single
+    | Optional
     deriving (Show, Eq, Ord)
 
 instance ToJSON ScriptArgArity where
     toJSON s = case s of
         Single -> Aeson.String "single"
+        Optional -> Aeson.String "optional"
 
 instance FromJSON ScriptArgArity where
     parseJSON v = case v of
         Aeson.String "single" -> pure Single
+        Aeson.String "optional" -> pure Optional
         _ ->
             fail $
                 List.unlines
@@ -75,6 +78,9 @@ instance FromJSON ScriptArgCallingMode where
                     [ "Invalid mode: " <> show v
                     , "allowed values are:"
                     , "- positional"
+                    , "- stdin"
+                    , "- dashdashspace"
+                    , "- dashdashequal"
                     ]
 
 data ScriptArg

--- a/tools/net-expert/ping.sh
+++ b/tools/net-expert/ping.sh
@@ -22,3 +22,4 @@ EOD
     ping -c 3 $2
   ;;
 esac
+


### PR DESCRIPTION
Add possibility to record per-agent (with extended conversation tracking) memories.
The structure is pretty OK I think, payloads could probably benefit from additional data-extractions (for now the whole history gets attached, and thus grows unbounded with various steps).

![Screenshot from 2025-05-24 20-11-28](https://github.com/user-attachments/assets/3d00f552-1b7f-4a8f-b800-416bff746aa6)
