### PR TITLE
Reload tools in TUI

### DIFF
--- a/agents.cabal
+++ b/agents.cabal
@@ -72,6 +72,7 @@ library agents-lib
                     , System.Agents.Dialogues
                     , System.Agents.FileLoader
                     , System.Agents.FileLoader.JSON
+                    , System.Agents.FileNotification
                     , System.Agents.ToolRegistration
                     , System.Agents.Tools
                     , System.Agents.Tools.Trace
@@ -120,6 +121,7 @@ library agents-lib
                       process,
                       process-extras,
                       prodapi,
+                      fsnotify,
                       stm,
                       stm-conduit,
                       text,

--- a/agents.cabal
+++ b/agents.cabal
@@ -60,7 +60,7 @@ library agents-lib
     default-language: Haskell2010
     default-extensions: OverloadedStrings, OverloadedRecordDot
     exposed-modules:  System.Agents
-                    , System.Agents.Agent
+                    , System.Agents.AgentTree
                     , System.Agents.ApiKeys
                     , System.Agents.Base
                     , System.Agents.Conversation
@@ -96,6 +96,7 @@ library agents-lib
                     , System.Agents.TUI.Handler
                     , System.Agents.TUI.State
                     , System.Agents.TUI.Render
+                    , System.Agents.TraceUtils
     build-depends:    base  >=4.18.3.0,
                       aeson >=2.2.0.0,
                       aeson-pretty,

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,7 +12,7 @@ import Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Prod.Tracer as Prod
-import qualified System.Agents.Agent as Agent
+import qualified System.Agents.AgentTree as AgentTree
 import System.Agents.Base (Agent (..), AgentId, AgentSlug, ConversationId, PingPongQuery (..))
 import qualified System.Agents.CLI as CLI
 import System.Agents.CLI.Base (makeShowLogFileTracer)
@@ -31,6 +31,7 @@ import qualified System.Agents.Tools.Bash as Bash
 import qualified System.Agents.Tools.Bash as ToolsTrace
 import qualified System.Agents.Tools.BashToolbox as BashToolbox
 import qualified System.Agents.Tools.IO as ToolsTrace
+import System.Agents.TraceUtils (traceWaitingOpenAIRateLimits)
 import System.Directory (getHomeDirectory)
 import System.FilePath ((</>))
 import System.IO (BufferMode (..), hSetBuffering, stderr, stdout)
@@ -232,75 +233,75 @@ main = do
 
         case args.mainCommand of
             Check -> do
-                apiKeys <- Agent.readOpenApiKeysFile args.apiKeysFile
+                apiKeys <- AgentTree.readOpenApiKeysFile args.apiKeysFile
                 forM_ args.agentFiles $ \agentFile -> do
                     OneShot.mainPrintAgent $
-                        Agent.Props
-                            { Agent.apiKeys = apiKeys
-                            , Agent.rootAgentFile = agentFile
-                            , Agent.interactiveTracer =
+                        AgentTree.Props
+                            { AgentTree.apiKeys = apiKeys
+                            , AgentTree.rootAgentFile = agentFile
+                            , AgentTree.interactiveTracer =
                                 Prod.traceBoth baseTracer traceUsefulPromptStdout
                             }
             InteractiveCommandLine -> do
-                apiKeys <- Agent.readOpenApiKeysFile args.apiKeysFile
+                apiKeys <- AgentTree.readOpenApiKeysFile args.apiKeysFile
                 let oneProp agentFile =
-                        Agent.Props
-                            { Agent.apiKeys = apiKeys
-                            , Agent.rootAgentFile = agentFile
-                            , Agent.interactiveTracer =
+                        AgentTree.Props
+                            { AgentTree.apiKeys = apiKeys
+                            , AgentTree.rootAgentFile = agentFile
+                            , AgentTree.interactiveTracer =
                                 Prod.traceBoth
                                     baseTracer
                                     ( Prod.traceBoth
                                         tracePrintingTextResponses
-                                        (Agent.traceWaitingOpenAIRateLimits (OpenAI.ApiLimits 100 10000) print)
+                                        (traceWaitingOpenAIRateLimits (OpenAI.ApiLimits 100 10000) print)
                                     )
                             }
                 CLI.mainInteractiveAgent $ map oneProp args.agentFiles
             TerminalUI -> do
-                apiKeys <- Agent.readOpenApiKeysFile args.apiKeysFile
+                apiKeys <- AgentTree.readOpenApiKeysFile args.apiKeysFile
                 let oneAgent agentFile =
-                        Agent.Props
-                            { Agent.apiKeys = apiKeys
-                            , Agent.rootAgentFile = agentFile
-                            , Agent.interactiveTracer =
+                        AgentTree.Props
+                            { AgentTree.apiKeys = apiKeys
+                            , AgentTree.rootAgentFile = agentFile
+                            , AgentTree.interactiveTracer =
                                 Prod.traceBoth
                                     baseTracer
-                                    (Agent.traceWaitingOpenAIRateLimits (OpenAI.ApiLimits 100 10000) print)
+                                    (traceWaitingOpenAIRateLimits (OpenAI.ApiLimits 100 10000) print)
                             }
                 TUI.mainMultiAgents (fmap oneAgent args.agentFiles)
             OneShot opts -> do
-                apiKeys <- Agent.readOpenApiKeysFile args.apiKeysFile
+                apiKeys <- AgentTree.readOpenApiKeysFile args.apiKeysFile
                 forM_ (take 1 args.agentFiles) $ \agentFile -> do
                     promptLines <- traverse interpretPromptArg opts.fileOrPromptArgs
                     let oneShot = flip OneShot.mainOneShotText
                     oneShot (Text.unlines promptLines) $
-                        Agent.Props
-                            { Agent.apiKeys = apiKeys
-                            , Agent.rootAgentFile = agentFile
-                            , Agent.interactiveTracer =
+                        AgentTree.Props
+                            { AgentTree.apiKeys = apiKeys
+                            , AgentTree.rootAgentFile = agentFile
+                            , AgentTree.interactiveTracer =
                                 Prod.traceBoth
                                     baseTracer
                                     traceUsefulPromptStderr
                             }
             SelfDescribe -> do
-                apiKeys <- Agent.readOpenApiKeysFile args.apiKeysFile
+                apiKeys <- AgentTree.readOpenApiKeysFile args.apiKeysFile
                 Aeson.encodeFile "/dev/stdout" $
                     Bash.ScriptInfo
                         []
                         "self-introspect"
                         "introspect a version of yourself"
             McpServer -> do
-                apiKeys <- Agent.readOpenApiKeysFile args.apiKeysFile
+                apiKeys <- AgentTree.readOpenApiKeysFile args.apiKeysFile
                 let oneAgent agentFile =
-                        Agent.Props
-                            { Agent.apiKeys = apiKeys
-                            , Agent.rootAgentFile = agentFile
-                            , Agent.interactiveTracer =
+                        AgentTree.Props
+                            { AgentTree.apiKeys = apiKeys
+                            , AgentTree.rootAgentFile = agentFile
+                            , AgentTree.interactiveTracer =
                                 Prod.traceBoth
                                     baseTracer
                                     ( Prod.traceBoth
                                         traceUsefulPromptStderr
-                                        (Agent.traceWaitingOpenAIRateLimits (OpenAI.ApiLimits 100 10000) (\_ -> pure ()))
+                                        (traceWaitingOpenAIRateLimits (OpenAI.ApiLimits 100 10000) (\_ -> pure ()))
                                     )
                             }
                 McpServer.multiAgentsServer (fmap oneAgent args.agentFiles)
@@ -336,9 +337,9 @@ maybeToEither :: Maybe a -> Either () a
 maybeToEither Nothing = Left ()
 maybeToEither (Just v) = Right v
 
-extractMemories :: Agent.Trace -> Either () [Memory.MemoryItem]
+extractMemories :: AgentTree.Trace -> Either () [Memory.MemoryItem]
 extractMemories x = case x of
-    Agent.AgentTrace tr -> go [] tr
+    AgentTree.AgentTrace tr -> go [] tr
     _ -> Left ()
   where
     parentInfo :: [Runtime.Trace] -> (Maybe AgentSlug, Maybe ConversationId, Maybe AgentId)
@@ -419,11 +420,11 @@ extractMemories x = case x of
         go (tr : xs) sub
     go _ _ = Left ()
 
-toJsonTrace :: Agent.Trace -> Maybe Aeson.Value
+toJsonTrace :: AgentTree.Trace -> Maybe Aeson.Value
 toJsonTrace x = case x of
-    Agent.DataLoadingTrace _ -> Nothing
-    Agent.AgentTrace v -> encodeAgentTrace v
-    Agent.ConfigLoadedTrace _ -> Nothing
+    AgentTree.DataLoadingTrace _ -> Nothing
+    AgentTree.AgentTrace v -> encodeAgentTrace v
+    AgentTree.ConfigLoadedTrace _ -> Nothing
   where
     encodeAgentTrace :: Runtime.Trace -> Maybe Aeson.Value
     encodeAgentTrace tr = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -423,6 +423,7 @@ toJsonTrace :: Agent.Trace -> Maybe Aeson.Value
 toJsonTrace x = case x of
     Agent.DataLoadingTrace _ -> Nothing
     Agent.AgentTrace v -> encodeAgentTrace v
+    Agent.ConfigLoadedTrace _ -> Nothing
   where
     encodeAgentTrace :: Runtime.Trace -> Maybe Aeson.Value
     encodeAgentTrace tr = do

--- a/src/System/Agents/AgentTree.hs
+++ b/src/System/Agents/AgentTree.hs
@@ -35,7 +35,10 @@ data Trace
     = AgentTrace Runtime.Trace
     | DataLoadingTrace FileLoader.Trace
     | ConfigLoadedTrace AgentConfigTree
-    deriving (Show)
+    deriving
+        ( -- | AgentInitialized AgentConfigTree Runtime
+          Show
+        )
 
 -------------------------------------------------------------------------------
 type LoadedApiKeys = [(Text, OpenAI.ApiKey)]

--- a/src/System/Agents/CLI.hs
+++ b/src/System/Agents/CLI.hs
@@ -13,7 +13,7 @@ import qualified Data.Maybe as Maybe
 import qualified Data.Text as Text
 import System.Console.Haskeline
 
-import System.Agents.Agent
+import System.Agents.AgentTree
 import System.Agents.CLI.State
 import qualified System.Agents.Conversation as Conversation
 import System.Agents.Dialogues

--- a/src/System/Agents/CLI.hs
+++ b/src/System/Agents/CLI.hs
@@ -26,7 +26,7 @@ mainInteractiveAgent xs =
 
 mainInteractiveAgent2 :: [LoadedAgent] -> [Props] -> IO ()
 mainInteractiveAgent2 agents (props : rest) = do
-    withAgentRuntime props $ \x -> do
+    withAgentTreeRuntime props $ \x -> do
         case x of
             Errors errs -> traverse_ print errs
             Initialized ai -> do

--- a/src/System/Agents/CLI/TraceUtils.hs
+++ b/src/System/Agents/CLI/TraceUtils.hs
@@ -54,6 +54,15 @@ traceUsefulPromptHandle h = Tracer f
     f (AgentTrace tr) =
         Text.hPutStrLn h $ renderAgentTrace tr
     f (DataLoadingTrace x) = Text.hPutStrLn h (Text.pack $ show x)
+    f (ConfigLoadedTrace x) =
+        Text.hPutStrLn h (showTree 0 x)
+      where
+        showTree :: Int -> AgentConfigTree -> Text.Text
+        showTree n v =
+            Text.unlines
+                [ Text.concat [Text.replicate n "  ", Text.pack v.agentConfigFile]
+                , Text.unlines $ fmap (showTree (succ n)) v.agentConfigChildren
+                ]
 
 renderAgentTrace :: Runtime.Trace -> Text
 renderAgentTrace (Runtime.AgentTrace_Loading slug _ tr) =

--- a/src/System/Agents/CLI/TraceUtils.hs
+++ b/src/System/Agents/CLI/TraceUtils.hs
@@ -15,7 +15,7 @@ import GHC.IO.Handle (Handle)
 import Prod.Tracer (Tracer (..), silent)
 import System.IO (stderr, stdout)
 
-import System.Agents.Agent
+import System.Agents.AgentTree
 import qualified System.Agents.LLMs.OpenAI as OpenAI
 import qualified System.Agents.Runtime.Trace as Runtime
 import qualified System.Agents.Tools as Tools

--- a/src/System/Agents/FileNotification.hs
+++ b/src/System/Agents/FileNotification.hs
@@ -46,9 +46,9 @@ isAboutFileChange ev = case ev of
     FSNotify.Added _ _ _ -> True
     FSNotify.CloseWrite _ _ _ -> True
     FSNotify.Modified _ _ _ -> True
-    FSNotify.ModifiedAttributes _ _ _ -> False
+    FSNotify.ModifiedAttributes _ _ _ -> True
+    FSNotify.Removed _ _ _ -> True
     FSNotify.Unknown _ _ _ _ -> False
-    FSNotify.Removed _ _ _ -> False
     FSNotify.WatchedDirectoryRemoved _ _ _ -> False
 
 getFilePath :: FSNotify.Event -> FilePath

--- a/src/System/Agents/FileNotification.hs
+++ b/src/System/Agents/FileNotification.hs
@@ -1,0 +1,53 @@
+-- todo: upstream to prodapi once the design settles
+module System.Agents.FileNotification where
+
+import Control.Concurrent.STM (STM, TMVar)
+import qualified Control.Concurrent.STM as STM
+import Control.Monad (void)
+import Prod.Tracer (Tracer, runTracer)
+import qualified System.FSNotify as FSNotify
+
+-------------------------------------------------------------------------------
+data Trace
+    = NotifyEvent FSNotify.Event
+
+-------------------------------------------------------------------------------
+-- note: would be nice to have some way to dynamically change the set of watched dirs
+data Runtime
+    = Runtime
+    { notifyManager :: FSNotify.WatchManager
+    , waitForChange :: STM ()
+    }
+
+-------------------------------------------------------------------------------
+initRuntime :: Tracer IO Trace -> FilePath -> (FSNotify.Event -> Bool) -> IO Runtime
+initRuntime tracer path shouldNotify = do
+    fsTVar <- STM.newEmptyTMVarIO
+    notify <- FSNotify.startManager
+    _ <- FSNotify.watchDir notify path shouldNotify (handleFSEvent fsTVar)
+    pure $ Runtime notify (STM.takeTMVar fsTVar)
+  where
+    handleFSEvent :: TMVar () -> FSNotify.Event -> IO ()
+    handleFSEvent x ev = do
+        runTracer tracer $ NotifyEvent ev
+        void $ STM.atomically $ STM.tryPutTMVar x ()
+
+isAboutFileChange :: FSNotify.Event -> Bool
+isAboutFileChange ev = case ev of
+    FSNotify.Added _ _ _ -> True
+    FSNotify.CloseWrite _ _ _ -> True
+    FSNotify.Modified _ _ _ -> True
+    FSNotify.ModifiedAttributes _ _ _ -> False
+    FSNotify.Unknown _ _ _ _ -> False
+    FSNotify.Removed _ _ _ -> False
+    FSNotify.WatchedDirectoryRemoved _ _ _ -> False
+
+getFilePath :: FSNotify.Event -> FilePath
+getFilePath ev = case ev of
+    FSNotify.Added p _ _ -> p
+    FSNotify.CloseWrite p _ _ -> p
+    FSNotify.Modified p _ _ -> p
+    FSNotify.ModifiedAttributes p _ _ -> p
+    FSNotify.Removed p _ _ -> p
+    FSNotify.Unknown p _ _ _ -> p
+    FSNotify.WatchedDirectoryRemoved p _ _ -> p

--- a/src/System/Agents/MCP/Server.hs
+++ b/src/System/Agents/MCP/Server.hs
@@ -45,7 +45,7 @@ multiAgentsServer' _ [] mtools = do
     logTrace =
         defaultOutput stderr
 multiAgentsServer' idx (props : xs) mtools = do
-    AgentTree.withAgentRuntime props go
+    AgentTree.withAgentTreeRuntime props go
   where
     go (AgentTree.Initialized ai) = do
         let oai = ai.agentBase

--- a/src/System/Agents/MCP/Server/Runtime.hs
+++ b/src/System/Agents/MCP/Server/Runtime.hs
@@ -18,11 +18,11 @@ import qualified Data.List as List
 import qualified Network.JSONRPC as Rpc
 import UnliftIO (Async, IORef, MonadIO, MonadUnliftIO, async, atomicModifyIORef, atomically, cancel, liftIO, newIORef, readIORef, wait, withAsync)
 
-import qualified System.Agents.Agent as Agent
+import qualified System.Agents.AgentTree as AgentTree
 import System.Agents.MCP.Base as Mcp
 
 data MappedTool
-    = ExpertAgentAsPrompt Mcp.Name Agent.AgentTree
+    = ExpertAgentAsPrompt Mcp.Name AgentTree.AgentTree
 
 type MappedTools = [MappedTool]
 

--- a/src/System/Agents/OneShot.hs
+++ b/src/System/Agents/OneShot.hs
@@ -15,14 +15,14 @@ import qualified System.Agents.Runtime as Runtime
 
 mainPrintAgent :: Props -> IO ()
 mainPrintAgent props = do
-    withAgentRuntime props $ \x -> do
+    withAgentTreeRuntime props $ \x -> do
         case x of
             Errors errs -> traverse_ print errs
             Initialized _ -> pure ()
 
 mainOneShotText :: Props -> Text -> IO ()
 mainOneShotText props query = do
-    withAgentRuntime props $ \x -> do
+    withAgentTreeRuntime props $ \x -> do
         case x of
             Errors errs -> traverse_ print errs
             Initialized ai -> runMainAgent ai.agentRuntime

--- a/src/System/Agents/OneShot.hs
+++ b/src/System/Agents/OneShot.hs
@@ -8,7 +8,7 @@ import qualified Data.Maybe as Maybe
 import Data.Text (Text)
 import qualified Data.Text.IO as Text
 
-import System.Agents.Agent
+import System.Agents.AgentTree
 import System.Agents.Base (newConversationId)
 import qualified System.Agents.LLMs.OpenAI as LLM
 import qualified System.Agents.Runtime as Runtime

--- a/src/System/Agents/TUI.hs
+++ b/src/System/Agents/TUI.hs
@@ -10,7 +10,7 @@ import Control.Monad (forever, void)
 import Data.Text (Text)
 import Prod.Tracer (Tracer (..))
 
-import System.Agents.Agent
+import System.Agents.AgentTree
 import System.Agents.Dialogues (LoadedAgent (..))
 import qualified System.Agents.Runtime as Runtime
 import System.Agents.TUI.Event

--- a/src/System/Agents/TUI.hs
+++ b/src/System/Agents/TUI.hs
@@ -36,7 +36,7 @@ runMultiAgents bChan agents = do
 
 mainMultiAgents2 :: BChan AppEvent -> Int -> [Props] -> [LoadedAgent] -> IO ()
 mainMultiAgents2 bChan idx (props : xs) agents = do
-    withAgentRuntime props go
+    withAgentTreeRuntime props go
   where
     go (Initialized ai) = do
         let oai = ai.agentBase

--- a/src/System/Agents/TUI/State.hs
+++ b/src/System/Agents/TUI/State.hs
@@ -74,14 +74,8 @@ newTuiState agents =
             <$> pure agents
             <*> newIORef []
     projectionsV =
-        let
-            readTools :: LoadedAgent -> IO (AgentId, [ToolRegistration])
-            readTools agent = do
-                x <- agent.loadedAgentRuntime.agentTools
-                pure (agent.loadedAgentRuntime.agentId, x)
-         in
-            Projections
-                <$> traverse readTools agents
+        Projections
+            <$> traverse readTools agents
     uiV =
         UI
             <$> pure (focusRing [UnifiedList, PromptEditor])
@@ -137,3 +131,8 @@ orderChatHandles items =
     orderByAgent (ChatEntryPoint la1) (ConversationEntryPoint c2) =
         let cmp = la1.loadedAgentInfo.slug `compare` c2.conversingAgent.slug
          in if cmp == EQ then LT else cmp
+
+readTools :: LoadedAgent -> IO (AgentId, [ToolRegistration])
+readTools agent = do
+    x <- agent.loadedAgentRuntime.agentTools
+    pure (agent.loadedAgentRuntime.agentId, x)

--- a/src/System/Agents/TraceUtils.hs
+++ b/src/System/Agents/TraceUtils.hs
@@ -1,0 +1,18 @@
+module System.Agents.TraceUtils where
+
+import Prod.Tracer (Tracer (..))
+
+import System.Agents.Agent (Trace (..))
+import qualified System.Agents.LLMs.OpenAI as OpenAI
+import qualified System.Agents.Runtime as Runtime
+
+-------------------------------------------------------------------------------
+traceWaitingOpenAIRateLimits ::
+    OpenAI.ApiLimits ->
+    (OpenAI.WaitAction -> IO ()) ->
+    Tracer IO Trace
+traceWaitingOpenAIRateLimits lims onWait = Tracer f
+  where
+    f (AgentTrace (Runtime.AgentTrace_Conversation _ _ _ (Runtime.LLMTrace _ tr))) =
+        runTracer (OpenAI.waitRateLimit lims onWait) tr
+    f _ = pure ()

--- a/src/System/Agents/TraceUtils.hs
+++ b/src/System/Agents/TraceUtils.hs
@@ -2,7 +2,7 @@ module System.Agents.TraceUtils where
 
 import Prod.Tracer (Tracer (..))
 
-import System.Agents.Agent (Trace (..))
+import System.Agents.AgentTree (Trace (..))
 import qualified System.Agents.LLMs.OpenAI as OpenAI
 import qualified System.Agents.Runtime as Runtime
 


### PR DESCRIPTION
Provides an initial solution and experiment platform to #7 . Each agent now has a file-watcher on its tool directory. The implementation may surface errors already possible because the filesystem dir-listing followed by file-loading operations being non atomic.

For now the implementation is a bit subpar compared to what we could do (e.g., having a single notification runtime per agent-tree or per application) but we'll fix that after implementing agent-reloading.