### PR TITLE
Support for acting as an MCP-Client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ so.  When an LLM requires more than one function, `agents-exe` runs all the
 functions concurrently.
 
 
-### Adding new tools
+### Adding new executable-program tools
 
 
 Tools are executable programs (often, you might want to encapsulate bash scripts) that adhere to the following specifications:
@@ -130,6 +130,40 @@ Agents-exe adheres to the same specifications, allowing you to use an
 `agents-exe` invocation directly as a tool. This flexibility is useful when
 running a hierarchy of agents with different access rights or across container
 boundaries. 
+
+### Adding new tools using an MCP-server
+
+Agents-exe can act as an MCP-client of MCP-servers.
+For now, only the local-executable transport is supported.
+
+Adding executables is as follows:
+
+```
+{
+  "tag": "OpenAIAgentDescription",
+  "contents": {
+    "slug": "my-agent",
+    "...": "other-structures",
+    "mcpServers": [
+      {
+        "tag": "McpSimpleBinary",
+        "contents": {
+          "name": "my-mcp-server",
+          "executable": "/path/to/executable",
+          "args": [
+            "arg0",
+            "arg1"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+For MCP-servers which do not advertise tools-changed notifications, agents-exe
+resorts to periodic polling to refresh tools list.
+
 
 ### Adding new agents
 
@@ -284,13 +318,19 @@ compatible with: OpenAI, OpenAI-claimed-compatible APIs, Ollama, others.
 
 ## MCP support
 
-- server: reloads/notifications
+- server: expose a toolregistration directly
+- server: forward tool-reloads/notifications
 - server: expose completion/prompt/resources, somehow
-- client mode as a consumer of tools
 - networked transport
 
 ## Framework features
 
 - internal machinery
-  - metrics and prodapi-endpoints
-  - we need to allow an orchestrator to introspect what happened
+  - http-server with metrics and/or prodapi-endpoints
+  - agents-tree reloading
+  - better async-linking when it makes sense
+- better CLI tooling
+  - to more-directly inspect/call a tool
+  - aggregate configs/tools definitions from different places
+  - make the 'cli' mode tolerable or remove it
+  - improve the 'tui' mode

--- a/agents.cabal
+++ b/agents.cabal
@@ -76,6 +76,7 @@ library agents-lib
                     , System.Agents.ToolRegistration
                     , System.Agents.Tools
                     , System.Agents.Tools.Trace
+                    , System.Agents.Tools.Base
                     , System.Agents.Tools.Bash
                     , System.Agents.Tools.BashToolbox
                     , System.Agents.Tools.IO

--- a/agents.cabal
+++ b/agents.cabal
@@ -119,6 +119,7 @@ library agents-lib
                       http-client,
                       http-client-tls,
                       http-types,
+                      indexed-traversable,
                       json-rpc,
                       lens,
                       monad-logger,

--- a/agents.cabal
+++ b/agents.cabal
@@ -89,6 +89,8 @@ library agents-lib
                     , System.Agents.HttpLogger
                     , System.Agents.OneShot
                     , System.Agents.MCP.Base
+                    , System.Agents.MCP.Client
+                    , System.Agents.MCP.Client.Runtime
                     , System.Agents.MCP.Server
                     , System.Agents.MCP.Server.Runtime
                     , System.Agents.TUI
@@ -105,6 +107,7 @@ library agents-lib
                       bytestring,
                       case-insensitive,
                       conduit,
+                      conduit-extra,
                       containers,
                       contravariant,
                       directory,
@@ -124,6 +127,7 @@ library agents-lib
                       prodapi,
                       fsnotify,
                       stm,
+                      stm-chans,
                       stm-conduit,
                       text,
                       text-zipper,

--- a/agents.cabal
+++ b/agents.cabal
@@ -79,6 +79,7 @@ library agents-lib
                     , System.Agents.Tools.Bash
                     , System.Agents.Tools.BashToolbox
                     , System.Agents.Tools.IO
+                    , System.Agents.Tools.McpToolbox
                     , System.Agents.LLMs.OpenAI
                     , System.Agents.Memory
                     , System.Agents.Runtime

--- a/agents.cabal
+++ b/agents.cabal
@@ -83,6 +83,7 @@ library agents-lib
                     , System.Agents.LLMs.OpenAI
                     , System.Agents.Memory
                     , System.Agents.Runtime
+                    , System.Agents.Runtime.Base
                     , System.Agents.Runtime.Conversation
                     , System.Agents.Runtime.Runtime
                     , System.Agents.Runtime.Trace

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Prod.Tracer as Prod
 import qualified System.Agents.AgentTree as AgentTree
-import System.Agents.Base (Agent (..), AgentId, AgentSlug, ConversationId, PingPongQuery (..))
+import System.Agents.Base (Agent (..), AgentId, AgentSlug, ConversationId, McpServerDescription (..), McpSimpleBinaryConfiguration (..), PingPongQuery (..))
 import qualified System.Agents.CLI as CLI
 import System.Agents.CLI.Base (makeShowLogFileTracer)
 import qualified System.Agents.CLI.InitProject as InitProject
@@ -22,6 +22,8 @@ import qualified System.Agents.HttpClient as HttpClient
 import qualified System.Agents.HttpLogger as HttpLogger
 import qualified System.Agents.LLMs.OpenAI as LLMTrace
 import qualified System.Agents.LLMs.OpenAI as OpenAI
+import qualified System.Agents.MCP.Client as McpClient
+import qualified System.Agents.MCP.Client.Runtime as McpClient
 import qualified System.Agents.MCP.Server as McpServer
 import qualified System.Agents.OneShot as OneShot
 import qualified System.Agents.Runtime.Trace as Runtime
@@ -31,6 +33,7 @@ import qualified System.Agents.Tools.Bash as Bash
 import qualified System.Agents.Tools.Bash as ToolsTrace
 import qualified System.Agents.Tools.BashToolbox as BashToolbox
 import qualified System.Agents.Tools.IO as ToolsTrace
+import qualified System.Agents.Tools.McpToolbox as McpTools
 import System.Agents.TraceUtils (traceWaitingOpenAIRateLimits)
 import System.Directory (getHomeDirectory)
 import System.FilePath ((</>))
@@ -324,6 +327,7 @@ main = do
                                 , "You notify users as you progress"
                                 , "If an agent fails, do not retry and abdicate"
                                 ]
+                            , mcpServers = Just []
                             }
                  in do
                         forM_ (take 1 args.agentFiles) $ \agentFile -> do
@@ -422,13 +426,14 @@ extractMemories x = case x of
 
 toJsonTrace :: AgentTree.Trace -> Maybe Aeson.Value
 toJsonTrace x = case x of
-    AgentTree.DataLoadingTrace _ -> Nothing
     AgentTree.AgentTrace v -> encodeAgentTrace v
+    AgentTree.McpTrace cfg v -> encodeMcpTrace cfg v
+    AgentTree.DataLoadingTrace _ -> Nothing
     AgentTree.ConfigLoadedTrace _ -> Nothing
   where
     encodeAgentTrace :: Runtime.Trace -> Maybe Aeson.Value
     encodeAgentTrace tr = do
-        baseVal <- encodeBaseTrace tr
+        baseVal <- encodeBaseAgentTrace tr
         Just $
             Aeson.object
                 [ "e"
@@ -439,12 +444,12 @@ toJsonTrace x = case x of
                         ]
                 ]
 
-    encodeBaseTrace :: Runtime.Trace -> Maybe Aeson.Value
-    encodeBaseTrace (Runtime.AgentTrace_Loading _ _ tr) =
+    encodeBaseAgentTrace :: Runtime.Trace -> Maybe Aeson.Value
+    encodeBaseAgentTrace (Runtime.AgentTrace_Loading _ _ tr) =
         encodeBaseTrace_Loading tr
-    encodeBaseTrace (Runtime.AgentTrace_Memorize _ _ _ tr) =
+    encodeBaseAgentTrace (Runtime.AgentTrace_Memorize _ _ _ tr) =
         encodeBaseTrace_Memorize tr
-    encodeBaseTrace (Runtime.AgentTrace_Conversation _ _ convId tr) = do
+    encodeBaseAgentTrace (Runtime.AgentTrace_Conversation _ _ convId tr) = do
         baseVal <- encodeBaseTrace_Conversation tr
         Just $
             Aeson.object
@@ -541,6 +546,60 @@ toJsonTrace x = case x of
             (Runtime.ChildrenTrace sub) -> do
                 subVal <- encodeAgentTrace sub
                 Just $ Aeson.object ["x" .= ("child" :: Text.Text), "sub" .= subVal]
+
+    encodeMcpTrace :: McpServerDescription -> McpTools.Trace -> Maybe Aeson.Value
+    encodeMcpTrace (McpSimpleBinary cfg) tr = do
+        baseVal <- encodeBaseMcpTrace tr
+        Just $
+            Aeson.object
+                [ "e"
+                    .= Aeson.object
+                        [ "server" .= cfg.name
+                        , "val" .= baseVal
+                        ]
+                ]
+
+    encodeBaseMcpTrace :: McpTools.Trace -> Maybe Aeson.Value
+    encodeBaseMcpTrace (McpTools.McpClientClientTrace _) = Nothing
+    encodeBaseMcpTrace
+        (McpTools.McpClientRunTrace (McpClient.RunCommandStart _)) =
+            Just $
+                Aeson.object
+                    [ "x" .= ("program-start" :: Text.Text)
+                    ]
+    encodeBaseMcpTrace
+        (McpTools.McpClientRunTrace (McpClient.RunCommandStopped _ code)) =
+            Just $
+                Aeson.object
+                    [ "x" .= ("program-end" :: Text.Text)
+                    , "code-str" .= show code -- todo: code
+                    ]
+    encodeBaseMcpTrace
+        (McpTools.McpClientLoopTrace McpClient.ExitingToolCallLoop) =
+            Just $
+                Aeson.object
+                    [ "x" .= ("loop-end" :: Text.Text)
+                    ]
+    encodeBaseMcpTrace
+        (McpTools.McpClientLoopTrace (McpClient.ToolsRefreshed _)) =
+            Just $
+                Aeson.object
+                    [ "x" .= ("tools-reloaded" :: Text.Text)
+                    ]
+    encodeBaseMcpTrace
+        (McpTools.McpClientLoopTrace (McpClient.StartToolCall n _)) =
+            Just $
+                Aeson.object
+                    [ "x" .= ("tool-call-start" :: Text.Text)
+                    , "name" .= n
+                    ]
+    encodeBaseMcpTrace
+        (McpTools.McpClientLoopTrace (McpClient.EndToolCall n _ _)) =
+            Just $
+                Aeson.object
+                    [ "x" .= ("tool-call-end" :: Text.Text)
+                    , "name" .= n
+                    ]
 
 makeHttpJsonTrace :: (Aeson.ToJSON a) => Prod.Tracer IO HttpClient.Trace -> Text.Text -> IO (Prod.Tracer IO a)
 makeHttpJsonTrace baseTracer url = do

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Prod.Tracer as Prod
 import qualified System.Agents.AgentTree as AgentTree
-import System.Agents.Base (Agent (..), AgentId, AgentSlug, ConversationId, McpServerDescription (..), McpSimpleBinaryConfiguration (..), PingPongQuery (..))
+import System.Agents.Base (Agent (..), AgentId, AgentSlug, ConversationId, McpServerDescription (..), McpSimpleBinaryConfiguration (..))
 import qualified System.Agents.CLI as CLI
 import System.Agents.CLI.Base (makeShowLogFileTracer)
 import qualified System.Agents.CLI.InitProject as InitProject
@@ -26,6 +26,7 @@ import qualified System.Agents.MCP.Client as McpClient
 import qualified System.Agents.MCP.Client.Runtime as McpClient
 import qualified System.Agents.MCP.Server as McpServer
 import qualified System.Agents.OneShot as OneShot
+import System.Agents.Runtime.Base (PingPongQuery (..))
 import qualified System.Agents.Runtime.Trace as Runtime
 import qualified System.Agents.TUI as TUI
 import qualified System.Agents.Tools as ToolsTrace

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -563,6 +563,9 @@ toJsonTrace x = case x of
     encodeBaseMcpTrace :: McpTools.Trace -> Maybe Aeson.Value
     encodeBaseMcpTrace (McpTools.McpClientClientTrace _) = Nothing
     encodeBaseMcpTrace
+        (McpTools.McpClientRunTrace (McpClient.RunBufferMoved _ _)) =
+            Nothing
+    encodeBaseMcpTrace
         (McpTools.McpClientRunTrace (McpClient.RunCommandStart _)) =
             Just $
                 Aeson.object

--- a/src/System/Agents/AgentTree.hs
+++ b/src/System/Agents/AgentTree.hs
@@ -14,7 +14,7 @@ import Data.Semigroup (sconcat)
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-import Prod.Tracer (Tracer (..), contramap, tracePrint)
+import Prod.Tracer (Tracer (..), contramap)
 import System.FilePath ((</>))
 import qualified System.FilePath as FilePath
 import System.Process (proc)
@@ -36,6 +36,7 @@ import System.Agents.ApiKeys
 -------------------------------------------------------------------------------
 data Trace
     = AgentTrace Runtime.Trace
+    | McpTrace McpServerDescription McpTools.Trace
     | DataLoadingTrace FileLoader.Trace
     | ConfigLoadedTrace AgentConfigTree
     deriving
@@ -187,9 +188,9 @@ initAgentTreeAgent tracer keys modifyPrompt helperAgents rootDir (AgentDescripti
                 mcpToolboxes
   where
     startMcp :: McpServerDescription -> IO McpTools.Toolbox
-    startMcp (McpSimpleBinary cfg) =
+    startMcp srv@(McpSimpleBinary cfg) =
         McpTools.initializeMcpToolbox
-            tracePrint
+            (contramap (McpTrace srv) tracer)
             cfg.name
             (proc cfg.executable (map Text.unpack cfg.args))
 

--- a/src/System/Agents/AgentTree.hs
+++ b/src/System/Agents/AgentTree.hs
@@ -229,8 +229,8 @@ turnAgentRuntimeIntoIOTool rt callerSlug callerId =
     props =
         [ LLM.ParamProperty
             { LLM.propertyKey = "what"
-            , LLM.propertyType = "string"
-            , LLM.propertyDescription = "the prompt to the other agent"
+            , LLM.propertyType = LLM.StringParamType
+            , LLM.propertyDescription = "the prompt to call the specialized-agent with"
             }
         ]
     io =

--- a/src/System/Agents/Base.hs
+++ b/src/System/Agents/Base.hs
@@ -48,6 +48,7 @@ data Agent
     , announce :: Text
     , systemPrompt :: [Text]
     , toolDirectory :: FilePath
+    , mcpServers :: Maybe [McpServerDescription]
     }
     deriving (Show, Ord, Eq, Generic)
 instance ToJSON Agent
@@ -70,6 +71,35 @@ instance FromJSON AgentDescription where
             "OpenAIAgentDescription" ->
                 AgentDescription <$> v .: "contents"
             _ -> fail "expecting OpenAIAgentDescription 'tag'"
+
+-------------------------------------------------------------------------------
+data McpSimpleBinaryConfiguration
+    = McpSimpleBinaryConfiguration
+    { name :: Text
+    , executable :: FilePath
+    , args :: [Text]
+    }
+    deriving (Show, Ord, Eq, Generic)
+
+instance FromJSON McpSimpleBinaryConfiguration
+instance ToJSON McpSimpleBinaryConfiguration
+data McpServerDescription
+    = McpSimpleBinary McpSimpleBinaryConfiguration
+    deriving (Show, Ord, Eq, Generic)
+instance ToJSON McpServerDescription where
+    toJSON (McpSimpleBinary val) =
+        Aeson.object
+            [ "tag" .= ("McpSimpleBinary" :: Text)
+            , "contents" .= val
+            ]
+
+instance FromJSON McpServerDescription where
+    parseJSON = Aeson.withObject "McpServerDescription" $ \v -> do
+        tag <- v .: "tag"
+        case (tag :: Text) of
+            "McpSimpleBinary" ->
+                McpSimpleBinary <$> v .: "contents"
+            _ -> fail "expecting McpSimpleBinary 'tag'"
 
 -------------------------------------------------------------------------------
 data PingPongQuery

--- a/src/System/Agents/Base.hs
+++ b/src/System/Agents/Base.hs
@@ -100,14 +100,3 @@ instance FromJSON McpServerDescription where
             "McpSimpleBinary" ->
                 McpSimpleBinary <$> v .: "contents"
             _ -> fail "expecting McpSimpleBinary 'tag'"
-
--------------------------------------------------------------------------------
-data PingPongQuery
-    = SomeQueryToAnswer Text
-    | GaveToolAnswers
-    | NoQuery
-    deriving (Show)
-
-getQueryToAnswer :: PingPongQuery -> Maybe Text
-getQueryToAnswer (SomeQueryToAnswer t) = Just t
-getQueryToAnswer _ = Nothing

--- a/src/System/Agents/CLI/TraceUtils.hs
+++ b/src/System/Agents/CLI/TraceUtils.hs
@@ -1,7 +1,11 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module System.Agents.CLI.TraceUtils where
+module System.Agents.CLI.TraceUtils (
+    tracePrintingTextResponses,
+    traceUsefulPromptStderr,
+    traceUsefulPromptStdout,
+) where
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Types as Aeson
@@ -12,7 +16,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
 import GHC.IO.Handle (Handle)
-import Prod.Tracer (Tracer (..), silent)
+import Prod.Tracer (Tracer (..))
 import System.IO (stderr, stdout)
 
 import System.Agents.AgentTree
@@ -22,9 +26,6 @@ import qualified System.Agents.Tools as Tools
 import qualified System.Agents.Tools.Bash as Tools
 import qualified System.Agents.Tools.BashToolbox as BashToolbox
 import qualified System.Agents.Tools.IO as Tools
-
-traceSilent :: Tracer IO Trace
-traceSilent = silent
 
 tracePrintingTextResponses :: Tracer IO Trace
 tracePrintingTextResponses = Tracer f
@@ -53,6 +54,8 @@ traceUsefulPromptHandle h = Tracer f
   where
     f (AgentTrace tr) =
         Text.hPutStrLn h $ renderAgentTrace tr
+    f (McpTrace _ tr) =
+        Text.hPutStrLn h (Text.pack $ show tr)
     f (DataLoadingTrace x) = Text.hPutStrLn h (Text.pack $ show x)
     f (ConfigLoadedTrace x) =
         Text.hPutStrLn h (showTree 0 x)

--- a/src/System/Agents/LLMs/OpenAI.hs
+++ b/src/System/Agents/LLMs/OpenAI.hs
@@ -226,18 +226,6 @@ data Tool = Tool
     }
     deriving (Show)
 
--- TODO: decide on format
--- type:'function'
--- name:string
--- description:string
--- properties.type:'object'
--- properties.strict:'true'
--- properties.parameters:object
--- properties.parameters.type:'object'
--- properties.parameters.required:[]string
--- properties.parameters.additionalProperties:'false'
--- properties.parameters.parameters:object
--- https://platform.openai.com/docs/guides/function-calling?api-mode=responses&example=send-email
 instance ToJSON Tool where
     toJSON t =
         Aeson.object

--- a/src/System/Agents/MCP/Base.hs
+++ b/src/System/Agents/MCP/Base.hs
@@ -259,7 +259,7 @@ instance FromJSON Tool where
 
 data InputSchema = InputSchema
     { required :: Maybe [Text]
-    , properties :: Maybe Aeson.Object
+    , properties :: Maybe Aeson.Object -- todo: consider a (recursive) KeyMap of schema properties
     }
     deriving (Show)
 

--- a/src/System/Agents/MCP/Base.hs
+++ b/src/System/Agents/MCP/Base.hs
@@ -55,7 +55,7 @@ instance FromJSON Annotation where
 
 data TextContentImpl = TextContentImpl
     { text :: Text
-    , annotations :: [Annotation]
+    , annotations :: Maybe [Annotation]
     }
     deriving (Show)
 
@@ -64,7 +64,7 @@ instance FromJSON TextContentImpl where
         guardTypeTag o "text"
         TextContentImpl
             <$> o .: "text"
-            <*> o .: "annotations"
+            <*> o .:? "annotations"
 
 instance ToJSON TextContentImpl where
     toJSON t =

--- a/src/System/Agents/MCP/Base.hs
+++ b/src/System/Agents/MCP/Base.hs
@@ -653,6 +653,10 @@ data ResourceUpdatedNotification = ResourceUpdatedNotification
 
 data PromptListChangedNotification = PromptListChangedNotification
 data ToolListChangedNotification = ToolListChangedNotification
+    deriving (Show)
+
+instance Aeson.FromJSON ToolListChangedNotification where
+    parseJSON _ = pure ToolListChangedNotification
 
 data LoggingMessageNotification = LoggingMessageNotification
     { level :: LoggingLevel

--- a/src/System/Agents/MCP/Client.hs
+++ b/src/System/Agents/MCP/Client.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module System.Agents.MCP.Client where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad.Logger (Loc, LogLevel, LogSource, LogStr, LoggingT (..), MonadLogger, MonadLoggerIO, logDebugN, runStderrLoggingT)
+import Control.Monad.Reader (MonadReader (..), ReaderT, ask, runReaderT)
+import Control.Monad.Trans (lift)
+import qualified Data.Aeson as Aeson
+import Data.Conduit.TMChan
+import qualified Data.Text as Text
+import qualified Network.JSONRPC as Rpc
+import UnliftIO (Async, MonadIO, MonadUnliftIO, async, atomically, cancel, liftIO, wait, withAsync)
+
+import System.Agents.MCP.Base as Mcp
+import System.Agents.MCP.Client.Runtime
+
+data Trace
+    = ProcessLevelTrace Loc LogSource LogLevel LogStr
+    deriving (Show)
+
+newtype McpStack a
+    = McpStack {runMcpStack :: ReaderT Runtime (LoggingT IO) a}
+    deriving (Functor, Applicative, Monad, MonadIO, MonadLogger, MonadLoggerIO, MonadUnliftIO)
+
+instance MonadReader Runtime McpStack where
+    ask = McpStack ask
+    local f (McpStack a) = McpStack (local f a)
+
+askRuntime :: Rpc.JSONRPCT McpStack Runtime
+askRuntime = lift ask
+
+debugString :: String -> Rpc.JSONRPCT McpStack ()
+debugString = logDebugN . Text.pack
+
+debugShow :: (Show a) => a -> Rpc.JSONRPCT McpStack ()
+debugShow = debugString . show
+
+toto :: Runtime -> IO ()
+toto rt = do
+    runStderrLoggingT $
+        runReaderT (runMcpStack scheduleMcp) rt
+  where
+    scheduleMcp = do
+        runJSONRPCT'
+            Rpc.V2
+            False
+            (sinkTBMChan rt.reqChan)
+            (sourceTBMChan rt.rspChan)
+            handlerLoop
+
+data ClientMsg
+    = InitializeMsg Mcp.InitializeRequest
+    deriving (Show)
+
+newtype InitializeResultRsp = InitializeResultRsp {getInitializeResult :: Mcp.InitializeResult}
+    deriving (Show, Aeson.FromJSON)
+
+instance Rpc.ToRequest ClientMsg where
+    requestMethod _ = "initialize"
+    requestIsNotif _ = False
+
+instance Rpc.FromResponse InitializeResultRsp where
+    parseResult "initialize" =
+        Just Aeson.parseJSON
+    parseResult _ = Nothing
+
+instance Aeson.ToJSON ClientMsg where
+    toJSON (InitializeMsg msg) = Aeson.toJSON msg
+
+handlerLoop :: Rpc.JSONRPCT McpStack ()
+handlerLoop = do
+    srv <- initialize
+    case srv of
+        (Just (Right srv)) -> loop srv
+  where
+    initialize :: Rpc.JSONRPCT McpStack (Maybe (Either Rpc.ErrorObj InitializeResultRsp))
+    initialize =
+        Rpc.sendRequest $
+            InitializeMsg $
+                Mcp.InitializeRequest
+                    "2024-11-05"
+                    ( Mcp.ClientCapabilities
+                        Nothing
+                        Nothing
+                        []
+                    )
+                    (Mcp.Implementation "agents-exe-mcp-client" "0.0.1")
+
+    loop :: InitializeResultRsp -> Rpc.JSONRPCT McpStack ()
+    loop srv = do
+        -- todo: need to cycle between requests and responses
+        debugString "hello"
+        liftIO $ threadDelay 1000000
+        loop srv

--- a/src/System/Agents/MCP/Client.hs
+++ b/src/System/Agents/MCP/Client.hs
@@ -221,7 +221,8 @@ defaultLoop :: LoopProps -> ClientInfos -> Rpc.JSONRPCT McpStack ()
 defaultLoop props clientInfos = do
     withAsync loopToolCalls $ \x -> do
         if hasToolsChangedNotif
-            then
+            then do
+                doRefreshTools
                 loopEnumerateTools_Notif
             else
                 loopEnumerateTools_Poll

--- a/src/System/Agents/MCP/Client.hs
+++ b/src/System/Agents/MCP/Client.hs
@@ -272,13 +272,15 @@ defaultLoop props clientInfos = do
     loopEnumerateTools_Poll :: Rpc.JSONRPCT McpStack ()
     loopEnumerateTools_Poll = do
         doRefreshTools
-        liftIO (threadDelay 3000000)
+        liftIO (threadDelay 30000000)
         loopEnumerateTools_Poll
 
     loopToolCalls :: Rpc.JSONRPCT McpStack ()
     loopToolCalls = do
         tc <- liftIO props.waitToolCall
         case tc of
+            Nothing -> do
+                liftIO $ runTracer props.tracer ExitingToolCallLoop
             Just (FullToolCall (ToolCall name obj) resp) -> do
                 liftIO $ runTracer props.tracer (StartToolCall name obj)
                 _ <- async $ do
@@ -287,5 +289,3 @@ defaultLoop props clientInfos = do
                         runTracer props.tracer (EndToolCall name obj r)
                         resp r
                 loopToolCalls
-            Nothing -> do
-                liftIO $ runTracer props.tracer ExitingToolCallLoop

--- a/src/System/Agents/MCP/Client/Runtime.hs
+++ b/src/System/Agents/MCP/Client/Runtime.hs
@@ -1,0 +1,81 @@
+module System.Agents.MCP.Client.Runtime where
+
+import Conduit (ConduitT, Flush, Void, (.|))
+import qualified Conduit as C
+import Control.Monad.Logger (MonadLoggerIO)
+import Control.Monad.Reader (runReaderT)
+import qualified Data.Aeson as Aeson
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as L8
+import Data.Conduit.Process (sourceProcessWithStreams)
+import Data.Conduit.TMChan
+import qualified Network.JSONRPC as Rpc
+import System.Exit (ExitCode)
+import System.Process (CreateProcess)
+import UnliftIO (Async, MonadUnliftIO, async, atomically, liftIO, wait, withAsync)
+
+data Runtime = Runtime
+    { processAsync :: Async (ExitCode)
+    , reqChan :: TBMChan (Flush ByteString)
+    , rspChan :: TBMChan ByteString
+    }
+
+initRuntime :: CreateProcess -> IO (Runtime)
+initRuntime proc = do
+    outChan <- newTBMChanIO 1024 :: IO (TBMChan ByteString)
+    inChan <- newTBMChanIO 1024 :: IO (TBMChan (Flush ByteString))
+    let process :: IO ExitCode
+        process = do
+            (code, _, _) <-
+                sourceProcessWithStreams
+                    proc
+                    (sourceTBMChan inChan .| discardFlush)
+                    (sinkTBMChan outChan)
+                    C.sinkNull
+            pure code
+    a <- async $ process
+    pure $ Runtime a inChan outChan
+
+discardFlush :: (Monad m) => ConduitT (Flush a) a m ()
+discardFlush = do
+    C.awaitForever $ \c -> do
+        case c of
+            C.Flush -> pure ()
+            (C.Chunk buf) -> C.yield buf
+
+-- A modified runJSONRPCT that allows to flush and add a carriage return after
+-- every full json payload (the original code only allows bytestrings).
+runJSONRPCT' ::
+    (MonadLoggerIO m, MonadUnliftIO m) =>
+    -- | JSON-RPC version
+    Rpc.Ver ->
+    -- | Ignore incoming requests/notifs
+    Bool ->
+    -- | Sink to send messages
+    ConduitT (Flush ByteString) Void m () ->
+    -- | Source to receive messages from
+    ConduitT () ByteString m () ->
+    -- | JSON-RPC action
+    Rpc.JSONRPCT m a ->
+    -- | Output of action
+    m a
+runJSONRPCT' ver ignore snk src f = do
+    qs <- liftIO . atomically $ Rpc.initSession ver ignore
+    let inSnk = sinkTBMChan (Rpc.inCh qs)
+        outSrc = sourceTBMChan (Rpc.outCh qs)
+    withAsync ((C.runConduit $ src .| Rpc.decodeConduit ver .| inSnk) >> liftIO (atomically $ closeTBMChan $ Rpc.inCh qs)) $
+        const $
+            withAsync (C.runConduit $ outSrc .| encodeConduit .| snk) $ \o ->
+                withAsync (runReaderT Rpc.processIncoming qs) $ const $ do
+                    a <- runReaderT f qs
+                    liftIO $ do
+                        atomically . closeTBMChan $ Rpc.outCh qs
+                        _ <- wait o
+                        return a
+
+encodeConduit :: (Aeson.ToJSON j, Monad m) => ConduitT j (Flush ByteString) m ()
+encodeConduit = do
+    C.awaitForever $ \m -> do
+        C.yield $ C.Chunk . L8.toStrict $ Aeson.encode m
+        C.yield $ C.Chunk "\n"
+        C.yield C.Flush

--- a/src/System/Agents/MCP/Server.hs
+++ b/src/System/Agents/MCP/Server.hs
@@ -78,7 +78,11 @@ serverImplem :: Mcp.Implementation
 serverImplem = Implementation "agents-exe-mcp-server" "0.0.1"
 
 serverCapabilities :: Mcp.ServerCapabilities
-serverCapabilities = Mcp.ServerCapabilities (Just mempty) (Just $ Aeson.object []) [ToolsListChanged, PromptsListChanged, ResourcesListChanged]
+serverCapabilities =
+    Mcp.ServerCapabilities
+        (Just mempty)
+        (Just $ Aeson.object [])
+        [ToolsListChanged, PromptsListChanged, ResourcesListChanged]
 
 -------------------------------------------------------------------------------
 data ClientMsg

--- a/src/System/Agents/MCP/Server.hs
+++ b/src/System/Agents/MCP/Server.hs
@@ -240,10 +240,10 @@ extractPrompt (Mcp.CallToolRequest _ (Just arg)) =
 
 toolCallContent :: Either String OpenAI.Response -> Mcp.Content
 toolCallContent (Left err) =
-    Mcp.TextContent $ Mcp.TextContentImpl (Text.unwords ["got an error:", Text.pack err]) []
+    Mcp.TextContent $ Mcp.TextContentImpl (Text.unwords ["got an error:", Text.pack err]) (Just [])
 toolCallContent (Right rsp) =
     case rsp.rspContent of
         Nothing ->
-            Mcp.TextContent $ Mcp.TextContentImpl ("got no anwser but it finished") []
+            Mcp.TextContent $ Mcp.TextContentImpl ("got no anwser but it finished") (Just [])
         Just txt ->
-            Mcp.TextContent $ Mcp.TextContentImpl (txt) []
+            Mcp.TextContent $ Mcp.TextContentImpl (txt) (Just [])

--- a/src/System/Agents/MCP/Server.hs
+++ b/src/System/Agents/MCP/Server.hs
@@ -224,7 +224,7 @@ callExpertTool mcpName ai =
                             [ "prompt"
                                 .= Mcp.object
                                     [ "type" .= ("string" :: Text)
-                                    , "title" .= ("the prompt asked when calling the expert" :: Text)
+                                    , "description" .= ("the prompt asked when calling the expert" :: Text)
                                     ]
                             ]
                     )

--- a/src/System/Agents/Memory.hs
+++ b/src/System/Agents/Memory.hs
@@ -6,6 +6,7 @@ import Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import System.Agents.Base
 import qualified System.Agents.LLMs.OpenAI as LLM
+import System.Agents.Runtime.Base (PingPongQuery (..))
 
 data MemoryItem
     = MemoryItem

--- a/src/System/Agents/Memory.hs
+++ b/src/System/Agents/Memory.hs
@@ -65,5 +65,20 @@ instance ToJSON MemoryItem where
                 , "raw" .= tool.rawToolCall
                 , "tool" .= tool.toolCallFunction.toolCallFunctionName.getToolName
                 , "args" .= tool.toolCallFunction.toolCallFunctionArgs
-                , "result" .= Text.decodeUtf8 res
+                , "result" .= encodeToolResponse res
+                ]
+        encodeToolResponse :: LLM.ToolResponse -> Aeson.Value
+        encodeToolResponse LLM.ToolNotFound =
+            Aeson.object
+                [ "type" .= ("not-found" :: Text)
+                ]
+        encodeToolResponse (LLM.TextToolResponse items) =
+            Aeson.object
+                [ "type" .= ("text" :: Text)
+                , "items" .= items
+                ]
+        encodeToolResponse (LLM.ToolFailure err) =
+            Aeson.object
+                [ "type" .= ("failure" :: Text)
+                , "err" .= err
                 ]

--- a/src/System/Agents/Runtime/Base.hs
+++ b/src/System/Agents/Runtime/Base.hs
@@ -1,0 +1,14 @@
+module System.Agents.Runtime.Base (PingPongQuery (..), getQueryToAnswer) where
+
+import Data.Text (Text)
+
+-------------------------------------------------------------------------------
+data PingPongQuery
+    = SomeQueryToAnswer Text
+    | GaveToolAnswers
+    | NoQuery
+    deriving (Show)
+
+getQueryToAnswer :: PingPongQuery -> Maybe Text
+getQueryToAnswer (SomeQueryToAnswer t) = Just t
+getQueryToAnswer _ = Nothing

--- a/src/System/Agents/Runtime/Conversation.hs
+++ b/src/System/Agents/Runtime/Conversation.hs
@@ -144,10 +144,10 @@ yankResults xs = fmap (\x -> (extractCall x, f x)) xs
     f (BashToolError _ err) =
         LLM.ToolFailure $ Text.pack $ show err
     f (McpToolError _ err) =
-        LLM.ToolFailure $ Text.pack $ show err
+        LLM.ToolFailure $ (Text.unlines ["tool-error", Text.pack (show err)])
     f (McpToolResult _ res) =
         case res.isError of
-            (Just True) -> LLM.ToolFailure $ aesonBlobify res
+            (Just True) -> LLM.ToolFailure (Text.unlines ["result-is-error:", aesonBlobify res])
             _ -> interpretMcpContents res.content
     f (IOToolError _ err) =
         LLM.ToolFailure $ Text.pack $ show err

--- a/src/System/Agents/Runtime/Conversation.hs
+++ b/src/System/Agents/Runtime/Conversation.hs
@@ -76,7 +76,7 @@ stepWith conversationId rt@(Runtime _ _ _ tracer httpRt model tools _) functions
     let query = getQueryToAnswer pendingQuery
     registeredTools <- tools
     let llmTools = fmap declareTool registeredTools
-    let payload = LLM.simplePayload model llmTools hist query
+    let payload = LLM.renderPayload model llmTools hist query
     stepUUID <- newStepId
     runTracer memoTracer (Calling pendingQuery hist stepUUID)
     llmResponse <- LLM.callLLMPayload (contramap (LLMTrace stepUUID) convTracer) httpRt model.modelBaseUrl payload

--- a/src/System/Agents/Runtime/Conversation.hs
+++ b/src/System/Agents/Runtime/Conversation.hs
@@ -20,6 +20,7 @@ import qualified System.Agents.LLMs.OpenAI as LLM
 import System.Agents.ToolRegistration
 import System.Agents.Tools
 
+import System.Agents.Runtime.Base
 import System.Agents.Runtime.Runtime
 import System.Agents.Runtime.Trace
 
@@ -134,3 +135,5 @@ yankResults xs = fmap (\x -> (extractCall x, f x)) xs
     f (BashToolError _ err) = CByteString.unlines ["the tool errored with:", CByteString.pack $ show err]
     f (IOToolError _ err) = CByteString.unlines ["the tool errored with:", CByteString.pack $ show err]
     f (ToolSuccess _ v) = v
+
+-------------------------------------------------------------------------------

--- a/src/System/Agents/Runtime/Runtime.hs
+++ b/src/System/Agents/Runtime/Runtime.hs
@@ -8,30 +8,17 @@ module System.Agents.Runtime.Runtime (
     triggerRefreshTools,
 ) where
 
-import Control.Concurrent.Async (mapConcurrently)
 import Control.Concurrent.STM (STM, atomically, readTVar)
-import Control.Concurrent.STM.TMVar (TMVar, newEmptyTMVarIO, takeTMVar, tryPutTMVar)
-import qualified Data.Aeson.Types as Aeson
-import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as CByteString
-import Data.Foldable (toList)
-import qualified Data.Maybe as Maybe
-import qualified Data.Sequence as Seq
-import Data.Text (Text)
+import Data.Either (rights)
 import qualified Data.Text.Encoding as Text
-import Data.UUID (UUID)
-import qualified Data.UUID.V4 as UUID
 import qualified Prod.Background as Background
-import Prod.Tracer (Tracer, contramap, runTracer, traceBoth)
+import Prod.Tracer (Tracer, contramap, traceBoth)
 import qualified System.Agents.HttpClient as HttpClient
 
-import System.Agents.Base
+import System.Agents.Base (AgentAnnounce, AgentId, AgentSlug, newAgentId)
 import qualified System.Agents.LLMs.OpenAI as LLM
 import System.Agents.ToolRegistration
-import System.Agents.Tools
-import qualified System.Agents.Tools.Bash as BashTools
 import qualified System.Agents.Tools.BashToolbox as BashToolbox
-import qualified System.Agents.Tools.IO as IOTools
 import qualified System.Agents.Tools.McpToolbox as McpTools
 
 import System.Agents.Runtime.Trace
@@ -95,116 +82,7 @@ newRuntime slug announce tracer apiKey model tooldir mkIoTools mcpToolboxes = do
   where
     readMcpToolsRegistrations :: IO [ToolRegistration]
     readMcpToolsRegistrations = do
+        -- TODO: would be nice to collect the lefts and trace errors upon relaoding
         lists <- traverse (atomically . readTVar . McpTools.toolsList) $ mcpToolboxes
-        let reg tb tds = [registerMcpToolInLLM tb td | td <- tds]
+        let reg tb tds = rights [registerMcpToolInLLM tb td | td <- tds]
         pure $ mconcat $ zipWith reg mcpToolboxes lists
-
-data ConversationFunctions r
-    = ConversationFunctions
-    { waitAdditionalQuery :: IO (Maybe Text)
-    , onProgress :: LLM.History -> IO ()
-    , onError :: String -> IO r
-    , onDone :: LLM.History -> IO r
-    }
-
-data ContinueD
-    = PromptMore !PingPongQuery !LLM.History
-    | OnDone !LLM.History
-    | OnError !String
-
-type ContinueFunction r = ContinueD -> IO r
-
-handleConversation :: forall r. Runtime -> ConversationFunctions r -> ConversationId -> Text -> IO r
-handleConversation rt functions conversationId startingPrompt = do
-    runTracer
-        rt.agentTracer
-        (AgentTrace_Conversation rt.agentSlug rt.agentId conversationId NewConversation)
-    go conversationId
-  where
-    go cId =
-        let step :: LLM.History -> PingPongQuery -> IO r
-            step = stepWith cId rt functions continue
-
-            continue :: ContinueFunction r
-            continue (PromptMore q h) = step h q
-            continue (OnError err) = functions.onError err
-            continue (OnDone h) = functions.onDone h
-         in step Seq.empty (SomeQueryToAnswer startingPrompt)
-
-stepWith ::
-    ConversationId ->
-    Runtime ->
-    ConversationFunctions r ->
-    ContinueFunction r ->
-    LLM.History ->
-    PingPongQuery ->
-    IO r
-stepWith conversationId rt _ next hist NoQuery = do
-    let memoTracer = contramap (AgentTrace_Memorize rt.agentSlug rt.agentId conversationId) rt.agentTracer
-    stepUUID <- newStepId
-    runTracer memoTracer (InteractionDone hist stepUUID)
-    next $ OnDone hist
-stepWith conversationId rt@(Runtime _ _ _ tracer httpRt model tools _) functions next hist pendingQuery = do
-    let convTracer = contramap (AgentTrace_Conversation rt.agentSlug rt.agentId conversationId) tracer
-    let memoTracer = contramap (AgentTrace_Memorize rt.agentSlug rt.agentId conversationId) tracer
-    let query = getQueryToAnswer pendingQuery
-    registeredTools <- tools
-    let llmTools = fmap declareTool registeredTools
-    let payload = LLM.simplePayload model llmTools hist query
-    stepUUID <- newStepId
-    runTracer memoTracer (Calling pendingQuery hist stepUUID)
-    llmResponse <- LLM.callLLMPayload (contramap (LLMTrace stepUUID) convTracer) httpRt model.modelBaseUrl payload
-    case Aeson.parseEither LLM.parseLLMResponse =<< llmResponse of
-        Right rsp -> do
-            let hist02 = hist <> Seq.singleton (LLM.PromptAnswered query rsp)
-            functions.onProgress hist02
-            runTracer memoTracer (GotResponse pendingQuery hist02 stepUUID rsp)
-            case Maybe.fromMaybe [] rsp.rspToolCalls of
-                [] -> do
-                    runTracer convTracer WaitingForPrompt
-                    nextQuery <- functions.waitAdditionalQuery
-                    next $
-                        PromptMore
-                            (maybe NoQuery SomeQueryToAnswer nextQuery)
-                            hist02
-                toolcalls -> do
-                    responses <- mapConcurrently (llmCallTool conversationId convTracer registeredTools) toolcalls
-                    let toolResults = fmap LLM.ToolCalled $ yankResults responses
-                    let hist03 = hist02 <> Seq.fromList toolResults
-                    next $
-                        PromptMore
-                            GaveToolAnswers
-                            hist03
-        Left err ->
-            next $ OnError err
-
-llmCallTool ::
-    ConversationId ->
-    Tracer IO ConversationTrace ->
-    [ToolRegistration] ->
-    LLM.ToolCall ->
-    IO (CallResult LLM.ToolCall)
-llmCallTool conversationId tracer registrations call =
-    let
-        script =
-            Maybe.listToMaybe $
-                Maybe.mapMaybe (\r -> r.findTool call) registrations
-        args = call.toolCallFunction.toolCallFunctionArgs
-        spec = (,) <$> script <*> args
-     in
-        case spec of
-            Nothing -> pure $ ToolNotFound call
-            Just (t, v) -> do
-                toolcallUUID <- newStepId
-                ret <- t.toolRun (contramap (RunToolTrace toolcallUUID) tracer) conversationId v
-                pure $ mapCallResult (const call) ret
-
--- TODO: improve on message handling here so that yankResults or default values are agent-specific
-yankResults :: [CallResult call] -> [(call, ByteString)]
-yankResults xs = fmap (\x -> (extractCall x, f x)) xs
-  where
-    f :: CallResult c -> ByteString
-    f (ToolNotFound _) = "the tool was not found"
-    f (BashToolError _ err) = CByteString.unlines ["the tool errored with:", CByteString.pack $ show err]
-    f (IOToolError _ err) = CByteString.unlines ["the tool errored with:", CByteString.pack $ show err]
-    f (ToolSuccess _ v) = v

--- a/src/System/Agents/Runtime/Trace.hs
+++ b/src/System/Agents/Runtime/Trace.hs
@@ -8,6 +8,8 @@ import qualified System.Agents.Tools.Bash as BashTools
 import qualified System.Agents.Tools.BashToolbox as BashToolbox
 import qualified System.Agents.Tools.IO as IOTools
 
+import System.Agents.Runtime.Base
+
 -------------------------------------------------------------------------------
 data Trace
     = AgentTrace_Loading !AgentSlug !AgentId !BashToolbox.Trace

--- a/src/System/Agents/TUI/Render.hs
+++ b/src/System/Agents/TUI/Render.hs
@@ -14,11 +14,13 @@ import System.Agents.Base (AgentId, PingPongQuery (..))
 import qualified System.Agents.Conversation as Conversation
 import qualified System.Agents.FileLoader as FileLoader
 import qualified System.Agents.LLMs.OpenAI as OpenAI
+import qualified System.Agents.MCP.Base as MCP
 import qualified System.Agents.Runtime as Runtime
 import System.Agents.ToolRegistration (ToolRegistration (..))
 import qualified System.Agents.Tools as Tools
 import qualified System.Agents.Tools.Bash as Tools
 import qualified System.Agents.Tools.IO as Tools
+import qualified System.Agents.Tools.McpToolbox as Tools
 
 import Brick
 import Brick.Focus (focusGetCurrent)
@@ -224,6 +226,8 @@ renderToolRegistry st aId =
                 Text.unwords ["command", Text.pack bashScript.scriptPath, Text.decodeUtf8 $ LByteString.toStrict $ Aeson.encode reg.declareTool]
             Tools.IOTool ioScript ->
                 Text.unwords ["io", ioScript.ioSlug, ioScript.ioDescription]
+            Tools.MCPTool desc ->
+                Text.unwords ["mcp", desc.getToolDescription.name, Maybe.fromMaybe "no description" desc.getToolDescription.description]
 
 separator :: Widget a
 separator = txt "=============="

--- a/src/System/Agents/TUI/Render.hs
+++ b/src/System/Agents/TUI/Render.hs
@@ -10,12 +10,13 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 
-import System.Agents.Base (AgentId, PingPongQuery (..))
+import System.Agents.Base (AgentId)
 import qualified System.Agents.Conversation as Conversation
 import qualified System.Agents.FileLoader as FileLoader
 import qualified System.Agents.LLMs.OpenAI as OpenAI
 import qualified System.Agents.MCP.Base as MCP
 import qualified System.Agents.Runtime as Runtime
+import System.Agents.Runtime.Base (PingPongQuery (..))
 import System.Agents.ToolRegistration (ToolRegistration (..))
 import qualified System.Agents.Tools as Tools
 import qualified System.Agents.Tools.Bash as Tools

--- a/src/System/Agents/ToolRegistration.hs
+++ b/src/System/Agents/ToolRegistration.hs
@@ -71,7 +71,7 @@ registerBashToolInLLM script =
         mapArg arg =
             LLM.ParamProperty
                 { LLM.propertyKey = arg.argName
-                , LLM.propertyType = arg.argBackingTypeString
+                , LLM.propertyType = LLM.OpaqueParamType arg.argBackingTypeString
                 , LLM.propertyDescription = arg.argDescription
                 }
 
@@ -170,7 +170,7 @@ adaptProperty k val =
             Right $
                 LLM.ParamProperty
                     (AesonKey.toText k)
-                    prop._type
+                    (LLM.OpaqueParamType prop._type)
                     prop._description
         Aeson.Error err -> Left err
   where
@@ -182,4 +182,4 @@ data PropertyHelper
 
 instance Aeson.FromJSON PropertyHelper where
     parseJSON = Aeson.withObject "PropertyHelper" $ \o ->
-        PropertyHelper <$> o Aeson..: "type" <*> o Aeson..: "title"
+        PropertyHelper <$> o Aeson..: "type" <*> o Aeson..: "description"

--- a/src/System/Agents/Tools.hs
+++ b/src/System/Agents/Tools.hs
@@ -86,7 +86,7 @@ mcpTool toolbox desc =
         ret <- McpTools.callTool toolbox desc (Just v)
         case ret of
             (Just (Right rsp)) -> pure $ extractContentsFromToolCall rsp
-            err -> pure $ McpToolError call (show err)
+            err -> pure $ McpToolError call (mconcat ["calling error: ", show err])
     run _ _ _ = do
         pure $ McpToolError call ("can only call McpTools with Aeson.Object")
     extractContentsFromToolCall :: McpClient.CallToolResultRsp -> CallResult ()

--- a/src/System/Agents/Tools.hs
+++ b/src/System/Agents/Tools.hs
@@ -87,6 +87,8 @@ mcpTool toolbox desc =
         case ret of
             (Just (Right rsp)) -> pure $ extractContentsFromToolCall rsp
             err -> pure $ McpToolError call (show err)
+    run _ _ _ = do
+        pure $ McpToolError call ("can only call McpTools with Aeson.Object")
     extractContentsFromToolCall :: McpClient.CallToolResultRsp -> CallResult ()
     extractContentsFromToolCall rsp =
         McpToolResult call rsp.getCallToolResult
@@ -123,6 +125,8 @@ extractCall (ToolNotFound c) = c
 extractCall (BashToolError c _) = c
 extractCall (IOToolError c _) = c
 extractCall (BlobToolSuccess c _) = c
+extractCall (McpToolResult c _) = c
+extractCall (McpToolError c _) = c
 
 -- | Explicit helper to map on the result of a CallResult.
 mapCallResult :: (a -> b) -> CallResult a -> CallResult b
@@ -132,6 +136,8 @@ mapCallResult f c =
         (BashToolError v e) -> BashToolError (f v) e
         (IOToolError v e) -> IOToolError (f v) e
         (BlobToolSuccess v b) -> BlobToolSuccess (f v) b
+        (McpToolResult v b) -> McpToolResult (f v) b
+        (McpToolError v b) -> McpToolError (f v) b
 
 -- | Explicit helper to map on the results a Tool makes.
 mapToolResult :: (a -> b) -> Tool x a -> Tool x b

--- a/src/System/Agents/Tools/Base.hs
+++ b/src/System/Agents/Tools/Base.hs
@@ -1,0 +1,17 @@
+module System.Agents.Tools.Base where
+
+-------------------------------------------------------------------------------
+import Data.ByteString.Char8 (ByteString)
+import qualified System.Agents.MCP.Base as Mcp
+import qualified System.Agents.Tools.Bash as BashTools
+import qualified System.Agents.Tools.IO as IOTools
+
+-------------------------------------------------------------------------------
+data CallResult call
+    = BlobToolSuccess call ByteString
+    | ToolNotFound call
+    | BashToolError call BashTools.RunScriptError
+    | IOToolError call IOTools.RunError
+    | McpToolResult call Mcp.CallToolResult
+    | McpToolError call String -- TODO: better error
+    deriving (Show)

--- a/src/System/Agents/Tools/McpToolbox.hs
+++ b/src/System/Agents/Tools/McpToolbox.hs
@@ -4,37 +4,57 @@ Note that reloads are asynchronous.
 module System.Agents.Tools.McpToolbox where
 
 import Control.Concurrent.Async (Async, async)
+import Control.Concurrent.MVar (newEmptyMVar, putMVar, takeMVar)
 import Control.Concurrent.STM (STM, atomically)
 import Control.Concurrent.STM.TBMChan (TBMChan, newTBMChanIO, readTBMChan, writeTBMChan)
 import Control.Concurrent.STM.TVar (TVar, newTVarIO, writeTVar)
+import qualified Data.Aeson as Aeson
 import qualified Data.Maybe as Maybe
+import Data.Text (Text)
+import qualified Network.JSONRPC as Rpc
 import Prod.Tracer (Tracer (..), silent)
 import System.Process (CreateProcess)
 
+import qualified System.Agents.MCP.Base as Mcp
 import System.Agents.MCP.Client (LoopProps (..), LoopTrace (..))
 import qualified System.Agents.MCP.Client as McpClient
 import qualified System.Agents.MCP.Client.Runtime as McpClient
 
 -------------------------------------------------------------------------------
+newtype ToolDescription = ToolDescription {getToolDescription :: Mcp.Tool}
+    deriving (Show)
+
 data Trace
     = McpClientLoopTrace !McpClient.LoopTrace
     deriving (Show)
 
-data BackgroundMcpTools = BackgroundMcpTools
-    { job :: Async ()
-    , enqueueCall :: McpClient.ToolCall -> STM ()
-    , toolsList :: TVar [McpClient.ListToolsResultRsp]
+data Toolbox = Toolbox
+    { name :: Text
+    , job :: Async ()
+    , toolsList :: TVar [ToolDescription]
+    , callTool :: ToolDescription -> Maybe Aeson.Object -> IO (McpClient.ToolCallResponse)
     }
 
 initializeMcpToolbox ::
     Tracer IO Trace ->
+    Text ->
     CreateProcess ->
-    IO BackgroundMcpTools
-initializeMcpToolbox tracer proc = do
+    IO Toolbox
+initializeMcpToolbox tracer name proc = do
     -- tool calls
     chan <- newTBMChanIO 30
     let nextToolCall = atomically $ readTBMChan chan
-    let enqueueCall = writeTBMChan chan
+    let callTool :: ToolDescription -> Maybe Aeson.Object -> IO McpClient.ToolCallResponse
+        callTool td param = do
+            let tc = McpClient.ToolCall td.getToolDescription.name param
+            mbox <- newEmptyMVar
+            let done res = do
+                    print "done, responding"
+                    putMVar mbox res
+            let fullcall = McpClient.FullToolCall tc done
+            atomically $ writeTBMChan chan fullcall
+            print "enqueued, waiting"
+            takeMVar mbox
 
     -- tool discovery
     discoveredTools <- newTVarIO []
@@ -48,9 +68,9 @@ initializeMcpToolbox tracer proc = do
     mcpRt <- McpClient.initRuntime rtTracer proc
     let props = LoopProps loopTracer nextToolCall
     job <- async (McpClient.runClient clientTracer mcpRt (McpClient.defaultLoop props))
-    pure $ BackgroundMcpTools job enqueueCall discoveredTools
+    pure $ Toolbox name job discoveredTools callTool
 
-storeToolsInDiscoveredValues :: TVar [McpClient.ListToolsResultRsp] -> Tracer IO LoopTrace
+storeToolsInDiscoveredValues :: TVar [ToolDescription] -> Tracer IO LoopTrace
 storeToolsInDiscoveredValues list = Tracer f
   where
     f :: LoopTrace -> IO ()
@@ -60,8 +80,10 @@ storeToolsInDiscoveredValues list = Tracer f
         atomically (writeTVar list [])
     f (ToolsRefreshed mitems) =
         let
-            f (Just (Right rsp)) = Just rsp
-            f _ = Nothing
-            items = Maybe.mapMaybe f mitems
+            f :: Maybe (Either Rpc.ErrorObj McpClient.ListToolsResultRsp) -> [ToolDescription]
+            f (Just (Right rsp)) = fmap ToolDescription rsp.getListToolsResult.tools
+            f _ = []
+
+            items = mconcat $ map f mitems
          in
             atomically (writeTVar list items)

--- a/src/System/Agents/Tools/McpToolbox.hs
+++ b/src/System/Agents/Tools/McpToolbox.hs
@@ -51,11 +51,9 @@ initializeMcpToolbox tracer name proc = do
             let tc = McpClient.ToolCall td.getToolDescription.name param
             mbox <- newEmptyMVar
             let done res = do
-                    print "done, responding"
                     putMVar mbox res
             let fullcall = McpClient.FullToolCall tc done
             atomically $ writeTBMChan chan fullcall
-            print "enqueued, waiting"
             takeMVar mbox
 
     -- tool discovery

--- a/src/System/Agents/Tools/McpToolbox.hs
+++ b/src/System/Agents/Tools/McpToolbox.hs
@@ -1,0 +1,67 @@
+{- | Provides a runtime value capable to load and reload a mcp list of tools.
+Note that reloads are asynchronous.
+-}
+module System.Agents.Tools.McpToolbox where
+
+import Control.Concurrent.Async (Async, async)
+import Control.Concurrent.STM (STM, atomically)
+import Control.Concurrent.STM.TBMChan (TBMChan, newTBMChanIO, readTBMChan, writeTBMChan)
+import Control.Concurrent.STM.TVar (TVar, newTVarIO, writeTVar)
+import qualified Data.Maybe as Maybe
+import Prod.Tracer (Tracer (..), silent)
+import System.Process (CreateProcess)
+
+import System.Agents.MCP.Client (LoopProps (..), LoopTrace (..))
+import qualified System.Agents.MCP.Client as McpClient
+import qualified System.Agents.MCP.Client.Runtime as McpClient
+
+-------------------------------------------------------------------------------
+data Trace
+    = McpClientLoopTrace !McpClient.LoopTrace
+    deriving (Show)
+
+data BackgroundMcpTools = BackgroundMcpTools
+    { job :: Async ()
+    , enqueueCall :: McpClient.ToolCall -> STM ()
+    , toolsList :: TVar [McpClient.ListToolsResultRsp]
+    }
+
+initializeMcpToolbox ::
+    Tracer IO Trace ->
+    CreateProcess ->
+    IO BackgroundMcpTools
+initializeMcpToolbox tracer proc = do
+    -- tool calls
+    chan <- newTBMChanIO 30
+    let nextToolCall = atomically $ readTBMChan chan
+    let enqueueCall = writeTBMChan chan
+
+    -- tool discovery
+    discoveredTools <- newTVarIO []
+    let toolsListTracer = storeToolsInDiscoveredValues discoveredTools
+    -- tracers
+    let rtTracer = silent
+    let clientTracer = silent
+    let loopTracer = toolsListTracer
+
+    -- wire things together
+    mcpRt <- McpClient.initRuntime rtTracer proc
+    let props = LoopProps loopTracer nextToolCall
+    job <- async (McpClient.runClient clientTracer mcpRt (McpClient.defaultLoop props))
+    pure $ BackgroundMcpTools job enqueueCall discoveredTools
+
+storeToolsInDiscoveredValues :: TVar [McpClient.ListToolsResultRsp] -> Tracer IO LoopTrace
+storeToolsInDiscoveredValues list = Tracer f
+  where
+    f :: LoopTrace -> IO ()
+    f (StartToolCall _ _) = pure ()
+    f (EndToolCall _ _ _) = pure ()
+    f (ExitingToolCallLoop) =
+        atomically (writeTVar list [])
+    f (ToolsRefreshed mitems) =
+        let
+            f (Just (Right rsp)) = Just rsp
+            f _ = Nothing
+            items = Maybe.mapMaybe f mitems
+         in
+            atomically (writeTVar list items)

--- a/src/System/Agents/Tools/Trace.hs
+++ b/src/System/Agents/Tools/Trace.hs
@@ -12,11 +12,3 @@ data ToolTrace
     = BashToolsTrace !BashTools.RunTrace
     | IOToolsTrace (IOTools.Trace Aeson.Value ByteString)
     deriving (Show)
-
-data CallResult call
-    = ToolSuccess call ByteString
-    | ToolNotFound call
-    | BashToolError call BashTools.RunScriptError
-    | IOToolError call IOTools.RunError
-    | McpToolError call String -- TODO: better error
-    deriving (Show)

--- a/src/System/Agents/Tools/Trace.hs
+++ b/src/System/Agents/Tools/Trace.hs
@@ -14,8 +14,9 @@ data ToolTrace
     deriving (Show)
 
 data CallResult call
-    = ToolNotFound call
+    = ToolSuccess call ByteString
+    | ToolNotFound call
     | BashToolError call BashTools.RunScriptError
     | IOToolError call IOTools.RunError
-    | ToolSuccess call ByteString
+    | McpToolError call String -- TODO: better error
     deriving (Show)


### PR DESCRIPTION
Adds initial support for acting as an MCP-client.

The architecture is so that most of the code is composable:
- MCP.Base contains the JSON structures
- MCP.Client.Runtime contains an stdio transport
- MCP.Client contains a a client-runtime
- MCP.Client contains a "Loop" that either polls for or get tools lists
- Tools.McpToolbox contains a Toolbox that maintains tools has a background value
- Tools contains mapping to/from internal definitions and the MCP definitions (with some loss sometimes)

Some extra changes in the LLM package modified the message structure from simple Text to allowing more structures.

Limitations (unclear to me):
- no auto-restart if the server crashes (we're not supposed to be systemd, but maybe we will)
- turns structured mcp-tool-outputs into textual-openAI-response-messages
- the JSON-schema supported subset is pretty minimal but it benefits the MCP-server too

Logging is still not great although we capture most of everything in traces.

Tested against agents-exe mcp-server and server-everything.