### PR TITLE
All tests pass. Let me provide a summary of what was implemented:

### DIFF
--- a/tasks-sessions/gh-143.session.md
+++ b/tasks-sessions/gh-143.session.md
@@ -4,6 +4,35 @@
 
 ---
 
+## Statistics
+
+### Turn Counts
+
+| Metric | Value |
+|--------|-------|
+| Total Turns | 46 |
+| User Turns | 23 |
+| LLM Turns | 23 |
+
+### Tool Calls
+
+**Total Tool Calls:** 29
+
+`bash_read-file      `   14 ████████████████████████████████████████████████████████████
+`bash_check-code     `    7 ██████████████████████████████
+`bash_write-file     `    6 █████████████████████████
+`bash_grep-files     `    1 ████
+`bash_list-files     `    1 ████
+
+### Byte Usage
+
+`Input     `    309 KiB ████████████████████████████████████████████████████████████
+`Output    `      2 KiB 
+`Reasoning `      5 KiB █
+**Total:** 317 KiB
+
+---
+
 ## Step 1: User Turn
 
 ### System Prompt


### PR DESCRIPTION
All tests pass. Let me provide a summary of what was implemented:

## Summary

I have implemented the `toolbox nest` command for `agents-exe` as specified in issue #143. Here's what was created:

### New Module: `src/System/Agents/Tools/Nest.hs`

This module provides the core nesting functionality:

**Data Types:**
- `NestOptions` - Configuration for the nest command (agent file, output path, tool name, include/exclude filters)
- `NestConfig` - Configuration embedded in the generated script
- `NestedToolRef` - Reference to a single nested tool
- `ToolType` - Enum for different tool types (Bash, MCP, IO, OpenAPI, PostgREST)

**Main Functions:**
- `runNestCommand` - Main entry point that orchestrates the nesting process
- `buildNestConfig` - Loads agent configuration and discovers all tools
- `generateNestedTool` - Generates the bash script content
- `writeNestedTool` - Writes the script with executable permissions

### Updated Files

1. **`app/Main.hs`**:
   - Added `ToolboxNest` command variant
   - Added CLI parser for `toolbox nest` subcommand with options:
     - `--agent-file` - Path to agent JSON
     - `--output` / `-o` - Output path for nested tool
     - `--name` / `-n` - Optional custom tool name
     - `--include-tool` - Include specific tools only
     - `--exclude-tool` - Exclude specific tools
   - Added `handleToolboxNest` handler

2. **`agents.cabal`**:
   - Added `System.Agents.Tools.Nest` to exposed modules

### Generated Script Structure

The generated bash script:
```bash
#!/bin/bash
# Embedded NEST_CONFIG JSON
case "$1" in
  describe)
    # Returns ScriptInfo with 'tool' and 'arg' parameters
    ;;
  run)
    # Parses --tool and --arg, dispatches to appropriate handler
    ;;
esac
```

**Features:**
- Implements standard bash-tool interface (`describe` and `run` commands)
- Embeds tool configuration as JSON
- For bash tools: calls the original script directly
- For MCP/IO/OpenAPI/PostgREST tools: generates placeholders that call back to `agents-exe`
- Sets executable permissions on output
- Supports tool filtering via include/exclude lists